### PR TITLE
Add GitLab support with optimized subdirectory downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 🚧 **Work in Progress** - This project is under active development.
 
-Simple GitHub repository downloader CLI tool.
+Simple Git repository downloader CLI tool supporting GitHub and GitLab.
 
 ## Installation
 
@@ -12,8 +12,10 @@ yarn global add baedal
 
 ## Usage
 
+### GitHub
+
 ```bash
-# Download entire repository
+# Download entire repository (defaults to GitHub)
 baedal user/repo
 
 # Download to specific directory
@@ -21,13 +23,36 @@ baedal user/repo ./output
 
 # Download specific folder or file
 baedal user/repo/src/components ./components
+
+# Explicit GitHub prefix
+baedal github:user/repo
+
+# Using GitHub URL
+baedal https://github.com/user/repo
+```
+
+### GitLab
+
+```bash
+# Download from GitLab using prefix
+baedal gitlab:user/repo
+
+# Download to specific directory
+baedal gitlab:user/repo ./output
+
+# Download specific folder or file
+baedal gitlab:user/repo/src/components ./components
+
+# Using GitLab URL
+baedal https://gitlab.com/user/repo
 ```
 
 ## Features
 
-- Download from GitHub repositories
+- Download from GitHub and GitLab repositories
 - Support for specific folders/files
 - Automatic branch detection (main/master)
+- Multiple input formats (prefix, URL, or simple user/repo)
 - Zero configuration
 
 ## Library Usage
@@ -35,9 +60,15 @@ baedal user/repo/src/components ./components
 ```typescript
 import { baedal } from "baedal";
 
+// GitHub (default)
 await baedal("user/repo");
 await baedal("user/repo", "./output");
 await baedal("user/repo/src", "./src");
+
+// GitLab
+await baedal("gitlab:user/repo");
+await baedal("gitlab:user/repo", "./output");
+await baedal("https://gitlab.com/user/repo/src", "./src");
 ```
 
 ## License

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { Provider } from "./providers.js";
+
 export type DownloadResult = {
   files: string[];
   path: string;
@@ -5,6 +7,7 @@ export type DownloadResult = {
 
 export type RepoInfo = {
   owner: string;
+  provider: Provider;
   repo: string;
   subdir?: string;
 };

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -1,4 +1,11 @@
+export type Provider = "github" | "gitlab";
+
 export const GITHUB_API_URL = "https://api.github.com";
 export const GITHUB_ARCHIVE_URL =
   "https://codeload.github.com/{owner}/{repo}/tar.gz/{branch}";
+
+export const GITLAB_API_URL = "https://gitlab.com/api/v4";
+export const GITLAB_ARCHIVE_URL =
+  "https://gitlab.com/{owner}/{repo}/-/archive/{branch}.tar.gz";
+
 export const DEFAULT_BRANCH = "main";

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,13 +1,17 @@
 import { ofetch } from "ofetch";
 import { createWriteStream } from "node:fs";
 import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
 import {
   GITHUB_API_URL,
   GITHUB_ARCHIVE_URL,
+  GITLAB_API_URL,
+  GITLAB_ARCHIVE_URL,
   DEFAULT_BRANCH,
+  type Provider,
 } from "../types/providers.js";
 
-const getDefaultBranch = async (
+const getGitHubDefaultBranch = async (
   owner: string,
   repo: string
 ): Promise<string> => {
@@ -21,18 +25,101 @@ const getDefaultBranch = async (
   }
 };
 
+const getGitLabDefaultBranch = async (
+  owner: string,
+  repo: string
+): Promise<string> => {
+  try {
+    const projectPath = encodeURIComponent(`${owner}/${repo}`);
+    const response = await ofetch<{ default_branch: string }>(
+      `${GITLAB_API_URL}/projects/${projectPath}`
+    );
+    return response.default_branch;
+  } catch {
+    return DEFAULT_BRANCH;
+  }
+};
+
+const getDefaultBranch = async (
+  owner: string,
+  repo: string,
+  provider: Provider
+): Promise<string> => {
+  return provider === "gitlab"
+    ? getGitLabDefaultBranch(owner, repo)
+    : getGitHubDefaultBranch(owner, repo);
+};
+
+const getArchiveUrl = (
+  owner: string,
+  repo: string,
+  branch: string,
+  provider: Provider,
+  subdir?: string
+): string => {
+  const template =
+    provider === "gitlab" ? GITLAB_ARCHIVE_URL : GITHUB_ARCHIVE_URL;
+
+  let url = template
+    .replace(/{owner}/g, owner)
+    .replace(/{repo}/g, repo)
+    .replace(/{branch}/g, branch);
+
+  // Add path parameter for GitLab subdirectory downloads
+  // This significantly reduces download size by filtering at the server side
+  if (provider === "gitlab" && subdir) {
+    url += `?path=${subdir}`;
+  }
+
+  return url;
+};
+
 export const downloadTarball = async (
   owner: string,
   repo: string,
-  destination: string
+  destination: string,
+  provider: Provider,
+  subdir?: string
 ): Promise<void> => {
-  const branch = await getDefaultBranch(owner, repo);
-  const url = GITHUB_ARCHIVE_URL.replace("{owner}", owner)
-    .replace("{repo}", repo)
-    .replace("{branch}", branch);
+  const branch = await getDefaultBranch(owner, repo, provider);
+  const url = getArchiveUrl(owner, repo, branch, provider, subdir);
 
-  const response = await ofetch(url, { responseType: "stream" });
+  // TODO: Unify fetch and ofetch usage
+  // Currently using native fetch for GitLab and ofetch for GitHub
+  // This could be simplified if ofetch supports mode: 'same-origin' option
+  //
+  // Use native fetch for GitLab with mode: 'same-origin' to avoid 406 error
+  // Reference: https://github.com/unjs/giget/issues/97
+  // GitLab has hotlinking protection that requires this mode
+
+  // Create readable stream based on provider
+  let stream;
+
+  if (provider === "gitlab") {
+    const response = await fetch(url, {
+      mode: "same-origin",
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download from GitLab: ${response.status} ${response.statusText}`
+      );
+    }
+
+    if (!response.body) {
+      throw new Error("Failed to download from GitLab: Response body is empty");
+    }
+
+    stream = Readable.fromWeb(response.body);
+  } else {
+    stream = await ofetch(url, {
+      responseType: "stream",
+      headers: {
+        Accept: "application/octet-stream, */*",
+      },
+    });
+  }
+
   const writeStream = createWriteStream(destination);
-
-  await pipeline(response, writeStream);
+  await pipeline(stream, writeStream);
 };

--- a/src/utils/extract.ts
+++ b/src/utils/extract.ts
@@ -31,6 +31,10 @@ export const extractTarball = async (
     }
   }
 
-  const files = await globby("**/*", { cwd: destination, onlyFiles: true });
+  const files = await globby("**/*", {
+    cwd: destination,
+    onlyFiles: true,
+    dot: true, // Include hidden files like .gitignore
+  });
   return files;
 };

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,13 +1,100 @@
+import { ofetch, FetchError } from "ofetch";
 import type { RepoInfo } from "../types/index.js";
+import type { Provider } from "../types/providers.js";
+import { GITLAB_API_URL } from "../types/providers.js";
 
-export const parseSource = (source: string): RepoInfo => {
-  const [owner, repo, ...subdirParts] = source.split("/");
+const GITLAB_VALIDATION_MAX_ATTEMPTS = 5;
+const GITLAB_API_TIMEOUT_MS = 5000;
+
+const detectProvider = (source: string): Provider => {
+  if (source.startsWith("gitlab:") || source.includes("gitlab.com")) {
+    return "gitlab";
+  }
+  if (source.startsWith("github:") || source.includes("github.com")) {
+    return "github";
+  }
+  return "github";
+};
+
+const validateGitLabProject = async (
+  parts: string[]
+): Promise<{ projectPath: string; subdir?: string }> => {
+  const maxAttempts = Math.min(parts.length, GITLAB_VALIDATION_MAX_ATTEMPTS);
+
+  for (let i = parts.length; i >= 2; i--) {
+    if (parts.length - i >= maxAttempts) break;
+
+    const projectPath = parts.slice(0, i).join("/");
+
+    try {
+      const encodedPath = encodeURIComponent(projectPath);
+      const url = `${GITLAB_API_URL}/projects/${encodedPath}`;
+
+      await ofetch(url, {
+        method: "GET",
+        timeout: GITLAB_API_TIMEOUT_MS,
+      });
+
+      const subdir = parts.slice(i).join("/");
+      return subdir ? { projectPath, subdir } : { projectPath };
+    } catch (error) {
+      // Only continue for 404 errors (project not found)
+      // Re-throw other errors (network issues, timeouts, etc.)
+      if (error instanceof FetchError && error.statusCode === 404) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  // If no valid project found after all attempts, throw error
+  throw new Error(
+    `Could not find a valid GitLab project for: ${parts.join("/")}`
+  );
+};
+
+export const parseSource = async (source: string): Promise<RepoInfo> => {
+  const provider = detectProvider(source);
+
+  let cleanSource = source
+    .replace(/^(github|gitlab):/, "")
+    .replace(/^https?:\/\/(github|gitlab)\.com\//, "");
+
+  const parts = cleanSource.split("/");
+
+  if (parts.length < 2) {
+    throw new Error(
+      "Invalid source format. Use: user/repo, github:user/repo, gitlab:user/repo, or full URL"
+    );
+  }
+
+  if (provider === "gitlab" && parts.length > 2) {
+    const { projectPath, subdir } = await validateGitLabProject(parts);
+
+    const pathParts = projectPath.split("/");
+    const owner = pathParts[0];
+    const repo = pathParts.slice(1).join("/");
+
+    if (!owner || !repo) {
+      throw new Error(
+        "Invalid source format. Use: user/repo, github:user/repo, gitlab:user/repo, or full URL"
+      );
+    }
+
+    return subdir
+      ? { owner, provider, repo, subdir }
+      : { owner, provider, repo };
+  }
+
+  const [owner, repo, ...subdirParts] = parts;
 
   if (!owner || !repo) {
-    throw new Error("Invalid source format. Use: user/repo or user/repo/path");
+    throw new Error(
+      "Invalid source format. Use: user/repo, github:user/repo, gitlab:user/repo, or full URL"
+    );
   }
 
   const subdir = subdirParts.join("/");
 
-  return subdir ? { owner, repo, subdir } : { owner, repo };
+  return subdir ? { owner, provider, repo, subdir } : { owner, provider, repo };
 };


### PR DESCRIPTION
- Add GitLab provider support
- Define Provider type and GitLab API URLs
- Support gitlab: prefix and GitLab URL parsing
- Implement server-side filtering with GitLab path parameter
- Download only requested subdirectory instead of full repository
- Test case gitlab-org/gitlab/doc: 2m17s → 10s (13.7x faster)
- Fix GitLab hotlinking protection
- Use mode: 'same-origin' to avoid 406 error
- Support hidden file counting (dot: true)
- Add GitLab usage examples to README

fix #11