### PR TITLE
Replace ofetch with ky to unify fetch implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "commander": "^12.0.0",
     "globby": "^14.0.0",
-    "ofetch": "^1.3.0",
+    "ky": "^1.8.3",
     "picocolors": "^1.0.0",
     "tar": "^7.5.1"
   },

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,4 +1,4 @@
-import { ofetch, FetchError } from "ofetch";
+import ky, { HTTPError } from "ky";
 import type { RepoInfo } from "../types/index.js";
 import type { Provider } from "../types/providers.js";
 import { GITLAB_API_URL } from "../types/providers.js";
@@ -30,8 +30,7 @@ const validateGitLabProject = async (
       const encodedPath = encodeURIComponent(projectPath);
       const url = `${GITLAB_API_URL}/projects/${encodedPath}`;
 
-      await ofetch(url, {
-        method: "GET",
+      await ky.get(url, {
         timeout: GITLAB_API_TIMEOUT_MS,
       });
 
@@ -40,7 +39,7 @@ const validateGitLabProject = async (
     } catch (error) {
       // Only continue for 404 errors (project not found)
       // Re-throw other errors (network issues, timeouts, etc.)
-      if (error instanceof FetchError && error.statusCode === 404) {
+      if (error instanceof HTTPError && error.response.status === 404) {
         continue;
       }
       throw error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,11 +468,6 @@ debug@^4.4.0:
   dependencies:
     ms "^2.1.3"
 
-destr@^2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.5.tgz#7d112ff1b925fb8d2079fac5bdb4a90973b51fdb"
-  integrity sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==
-
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -649,6 +644,11 @@ joycon@^3.1.1:
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
+ky@^1.8.3:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-1.11.0.tgz#85e80fab76034a7fc0790ee1e3d0897f69d882ab"
+  integrity sha512-NEyo0ICpS0cqSuyoJFMCnHOZJILqXsKhIZlHJGDYaH8OB5IFrGzuBpEwyoMZG6gUKMPrazH30Ax5XKaujvD8ag==
+
 lilconfig@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
@@ -742,24 +742,10 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-node-fetch-native@^1.6.4:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.7.tgz#9d09ca63066cc48423211ed4caf5d70075d76a71"
-  integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
-
 object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
-ofetch@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.4.1.tgz#b6bf6b0d75ba616cef6519dd8b6385a8bae480ec"
-  integrity sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==
-  dependencies:
-    destr "^2.0.3"
-    node-fetch-native "^1.6.4"
-    ufo "^1.5.4"
 
 package-json-from-dist@^1.0.0:
   version "1.0.1"
@@ -1068,7 +1054,7 @@ typescript@^5.3.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
-ufo@^1.5.4, ufo@^1.6.1:
+ufo@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.1.tgz#ac2db1d54614d1b22c1d603e3aef44a85d8f146b"
   integrity sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==


### PR DESCRIPTION
ofetch doesn't support mode: 'same-origin' option required for GitLab downloads, which forced using native fetch and created inconsistent code patterns

- package.json: Replace ofetch with ky
- download.ts: Remove type assertions with generics, simplify code by ~40%
- parser.ts: Remove AbortController boilerplate, use built-in timeout

fix #18