### PR TITLE
Refactor provider logic to core and simplify fetch options

### DIFF
--- a/src/core/providers/archive.ts
+++ b/src/core/providers/archive.ts
@@ -1,0 +1,49 @@
+import {
+  GITHUB_ARCHIVE_URL,
+  GITLAB_ARCHIVE_URL,
+  type Provider,
+} from "../../types/providers.js";
+import { getGitHubDefaultBranch } from "./github.js";
+import { getGitLabDefaultBranch } from "./gitlab.js";
+
+export const getDefaultBranch = async (
+  owner: string,
+  repo: string,
+  provider: Provider
+): Promise<string> => {
+  return provider === "gitlab"
+    ? getGitLabDefaultBranch(owner, repo)
+    : getGitHubDefaultBranch(owner, repo);
+};
+
+type GetArchiveUrlParams = {
+  branch: string;
+  owner: string;
+  provider: Provider;
+  repo: string;
+  subdir?: string;
+};
+
+export const getArchiveUrl = ({
+  branch,
+  owner,
+  provider,
+  repo,
+  subdir,
+}: GetArchiveUrlParams): string => {
+  const template =
+    provider === "gitlab" ? GITLAB_ARCHIVE_URL : GITHUB_ARCHIVE_URL;
+
+  let url = template
+    .replace(/{owner}/g, owner)
+    .replace(/{repo}/g, repo)
+    .replace(/{branch}/g, branch);
+
+  // Add path parameter for GitLab subdirectory downloads
+  // This significantly reduces download size by filtering at the server side
+  if (provider === "gitlab" && subdir) {
+    url += `?path=${subdir}`;
+  }
+
+  return url;
+};

--- a/src/core/providers/detector.ts
+++ b/src/core/providers/detector.ts
@@ -1,0 +1,8 @@
+import type { Provider } from "../../types/providers.js";
+
+export const detectProvider = (source: string): Provider => {
+  if (source.startsWith("gitlab:") || source.includes("gitlab.com")) {
+    return "gitlab";
+  }
+  return "github";
+};

--- a/src/core/providers/github.ts
+++ b/src/core/providers/github.ts
@@ -1,0 +1,20 @@
+import ky from "ky";
+import { GITHUB_API_URL, DEFAULT_BRANCH } from "../../types/providers.js";
+
+export const getGitHubDefaultBranch = async (
+  owner: string,
+  repo: string
+): Promise<string> => {
+  try {
+    const data = await ky
+      .get(`${GITHUB_API_URL}/repos/${owner}/${repo}`)
+      .json<{ default_branch: string }>();
+    return data.default_branch;
+  } catch (error) {
+    console.error(
+      `Failed to fetch GitHub default branch for ${owner}/${repo}:`,
+      error
+    );
+    return DEFAULT_BRANCH;
+  }
+};

--- a/src/core/providers/gitlab.ts
+++ b/src/core/providers/gitlab.ts
@@ -1,0 +1,60 @@
+import ky, { HTTPError } from "ky";
+import { GITLAB_API_URL, DEFAULT_BRANCH } from "../../types/providers.js";
+
+const GITLAB_VALIDATION_MAX_ATTEMPTS = 5;
+const GITLAB_API_TIMEOUT_MS = 5000;
+
+export const validateGitLabProject = async (
+  parts: string[]
+): Promise<{ projectPath: string; subdir?: string }> => {
+  const maxAttempts = Math.min(parts.length, GITLAB_VALIDATION_MAX_ATTEMPTS);
+
+  for (let i = parts.length; i >= 2; i--) {
+    if (parts.length - i >= maxAttempts) break;
+
+    const projectPath = parts.slice(0, i).join("/");
+
+    try {
+      const encodedPath = encodeURIComponent(projectPath);
+      const url = `${GITLAB_API_URL}/projects/${encodedPath}`;
+
+      await ky.get(url, {
+        timeout: GITLAB_API_TIMEOUT_MS,
+      });
+
+      const subdir = parts.slice(i).join("/");
+      return subdir ? { projectPath, subdir } : { projectPath };
+    } catch (error) {
+      // Only continue for 404 errors (project not found)
+      // Re-throw other errors (network issues, timeouts, etc.)
+      if (error instanceof HTTPError && error.response.status === 404) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  // If no valid project found after all attempts, throw error
+  throw new Error(
+    `Could not find a valid GitLab project for: ${parts.join("/")}`
+  );
+};
+
+export const getGitLabDefaultBranch = async (
+  owner: string,
+  repo: string
+): Promise<string> => {
+  try {
+    const projectPath = encodeURIComponent(`${owner}/${repo}`);
+    const data = await ky
+      .get(`${GITLAB_API_URL}/projects/${projectPath}`)
+      .json<{ default_branch: string }>();
+    return data.default_branch;
+  } catch (error) {
+    console.error(
+      `Failed to fetch GitLab default branch for ${owner}/${repo}:`,
+      error
+    );
+    return DEFAULT_BRANCH;
+  }
+};

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -2,77 +2,8 @@ import ky from "ky";
 import { createWriteStream } from "node:fs";
 import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
-import {
-  GITHUB_API_URL,
-  GITHUB_ARCHIVE_URL,
-  GITLAB_API_URL,
-  GITLAB_ARCHIVE_URL,
-  DEFAULT_BRANCH,
-  type Provider,
-} from "../types/providers.js";
-
-const getGitHubDefaultBranch = async (
-  owner: string,
-  repo: string
-): Promise<string> => {
-  try {
-    const data = await ky
-      .get(`${GITHUB_API_URL}/repos/${owner}/${repo}`)
-      .json<{ default_branch: string }>();
-    return data.default_branch;
-  } catch {
-    return DEFAULT_BRANCH;
-  }
-};
-
-const getGitLabDefaultBranch = async (
-  owner: string,
-  repo: string
-): Promise<string> => {
-  try {
-    const projectPath = encodeURIComponent(`${owner}/${repo}`);
-    const data = await ky
-      .get(`${GITLAB_API_URL}/projects/${projectPath}`)
-      .json<{ default_branch: string }>();
-    return data.default_branch;
-  } catch {
-    return DEFAULT_BRANCH;
-  }
-};
-
-const getDefaultBranch = async (
-  owner: string,
-  repo: string,
-  provider: Provider
-): Promise<string> => {
-  return provider === "gitlab"
-    ? getGitLabDefaultBranch(owner, repo)
-    : getGitHubDefaultBranch(owner, repo);
-};
-
-const getArchiveUrl = (
-  owner: string,
-  repo: string,
-  branch: string,
-  provider: Provider,
-  subdir?: string
-): string => {
-  const template =
-    provider === "gitlab" ? GITLAB_ARCHIVE_URL : GITHUB_ARCHIVE_URL;
-
-  let url = template
-    .replace(/{owner}/g, owner)
-    .replace(/{repo}/g, repo)
-    .replace(/{branch}/g, branch);
-
-  // Add path parameter for GitLab subdirectory downloads
-  // This significantly reduces download size by filtering at the server side
-  if (provider === "gitlab" && subdir) {
-    url += `?path=${subdir}`;
-  }
-
-  return url;
-};
+import type { Provider } from "../types/providers.js";
+import { getDefaultBranch, getArchiveUrl } from "../core/providers/archive.js";
 
 export const downloadTarball = async (
   owner: string,
@@ -82,7 +13,13 @@ export const downloadTarball = async (
   subdir?: string
 ): Promise<void> => {
   const branch = await getDefaultBranch(owner, repo, provider);
-  const url = getArchiveUrl(owner, repo, branch, provider, subdir);
+  const url = getArchiveUrl({
+    branch,
+    owner,
+    provider,
+    repo,
+    ...(subdir && { subdir }),
+  });
 
   // GitLab requires mode: 'same-origin' to avoid 406 error due to hotlinking protection
   // Reference: https://github.com/unjs/giget/issues/97

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,56 +1,6 @@
-import ky, { HTTPError } from "ky";
 import type { RepoInfo } from "../types/index.js";
-import type { Provider } from "../types/providers.js";
-import { GITLAB_API_URL } from "../types/providers.js";
-
-const GITLAB_VALIDATION_MAX_ATTEMPTS = 5;
-const GITLAB_API_TIMEOUT_MS = 5000;
-
-const detectProvider = (source: string): Provider => {
-  if (source.startsWith("gitlab:") || source.includes("gitlab.com")) {
-    return "gitlab";
-  }
-  if (source.startsWith("github:") || source.includes("github.com")) {
-    return "github";
-  }
-  return "github";
-};
-
-const validateGitLabProject = async (
-  parts: string[]
-): Promise<{ projectPath: string; subdir?: string }> => {
-  const maxAttempts = Math.min(parts.length, GITLAB_VALIDATION_MAX_ATTEMPTS);
-
-  for (let i = parts.length; i >= 2; i--) {
-    if (parts.length - i >= maxAttempts) break;
-
-    const projectPath = parts.slice(0, i).join("/");
-
-    try {
-      const encodedPath = encodeURIComponent(projectPath);
-      const url = `${GITLAB_API_URL}/projects/${encodedPath}`;
-
-      await ky.get(url, {
-        timeout: GITLAB_API_TIMEOUT_MS,
-      });
-
-      const subdir = parts.slice(i).join("/");
-      return subdir ? { projectPath, subdir } : { projectPath };
-    } catch (error) {
-      // Only continue for 404 errors (project not found)
-      // Re-throw other errors (network issues, timeouts, etc.)
-      if (error instanceof HTTPError && error.response.status === 404) {
-        continue;
-      }
-      throw error;
-    }
-  }
-
-  // If no valid project found after all attempts, throw error
-  throw new Error(
-    `Could not find a valid GitLab project for: ${parts.join("/")}`
-  );
-};
+import { detectProvider } from "../core/providers/detector.js";
+import { validateGitLabProject } from "../core/providers/gitlab.js";
 
 export const parseSource = async (source: string): Promise<RepoInfo> => {
   const provider = detectProvider(source);


### PR DESCRIPTION
Separate platform-specific business logic from utils

- Create core/providers directory for GitHub/GitLab business logic
  - detector.ts: Provider detection
  - github.ts: GitHub API calls
  - gitlab.ts: GitLab API calls and project validation
  - archive.ts: Archive URL generation and branch fetching
- Keep utils as pure utility functions only (parser, download, extract)
- Remove provider branching for mode option after verifying it works on GitHub

fix #20