### PR TITLE
Add Bitbucket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 🚧 **Work in Progress** - This project is under active development.
 
-Simple Git repository downloader CLI tool supporting GitHub and GitLab.
+Simple Git repository downloader CLI tool supporting GitHub, GitLab, and Bitbucket.
 
 ## Installation
 
@@ -47,9 +47,25 @@ baedal gitlab:user/repo/src/components ./components
 baedal https://gitlab.com/user/repo
 ```
 
+### Bitbucket
+
+```bash
+# Download from Bitbucket using prefix
+baedal bitbucket:user/repo
+
+# Download to specific directory
+baedal bitbucket:user/repo ./output
+
+# Download specific folder or file
+baedal bitbucket:user/repo/src/components ./components
+
+# Using Bitbucket URL
+baedal https://bitbucket.org/user/repo
+```
+
 ## Features
 
-- Download from GitHub and GitLab repositories
+- Download from GitHub, GitLab, and Bitbucket repositories
 - Support for specific folders/files
 - Automatic branch detection (main/master)
 - Multiple input formats (prefix, URL, or simple user/repo)
@@ -69,6 +85,11 @@ await baedal("user/repo/src", "./src");
 await baedal("gitlab:user/repo");
 await baedal("gitlab:user/repo", "./output");
 await baedal("https://gitlab.com/user/repo/src", "./src");
+
+// Bitbucket
+await baedal("bitbucket:user/repo");
+await baedal("bitbucket:user/repo", "./output");
+await baedal("https://bitbucket.org/user/repo/src", "./src");
 ```
 
 ## License

--- a/src/core/providers/archive.ts
+++ b/src/core/providers/archive.ts
@@ -1,19 +1,26 @@
 import {
   GITHUB_ARCHIVE_URL,
   GITLAB_ARCHIVE_URL,
+  BITBUCKET_ARCHIVE_URL,
   type Provider,
 } from "../../types/providers.js";
 import { getGitHubDefaultBranch } from "./github.js";
 import { getGitLabDefaultBranch } from "./gitlab.js";
+import { getBitbucketDefaultBranch } from "./bitbucket.js";
 
 export const getDefaultBranch = async (
   owner: string,
   repo: string,
   provider: Provider
 ): Promise<string> => {
-  return provider === "gitlab"
-    ? getGitLabDefaultBranch(owner, repo)
-    : getGitHubDefaultBranch(owner, repo);
+  switch (provider) {
+    case "gitlab":
+      return getGitLabDefaultBranch(owner, repo);
+    case "bitbucket":
+      return getBitbucketDefaultBranch(owner, repo);
+    default:
+      return getGitHubDefaultBranch(owner, repo);
+  }
 };
 
 type GetArchiveUrlParams = {
@@ -31,8 +38,19 @@ export const getArchiveUrl = ({
   repo,
   subdir,
 }: GetArchiveUrlParams): string => {
-  const template =
-    provider === "gitlab" ? GITLAB_ARCHIVE_URL : GITHUB_ARCHIVE_URL;
+  let template: string;
+
+  switch (provider) {
+    case "gitlab":
+      template = GITLAB_ARCHIVE_URL;
+      break;
+    case "bitbucket":
+      template = BITBUCKET_ARCHIVE_URL;
+      break;
+    default:
+      template = GITHUB_ARCHIVE_URL;
+      break;
+  }
 
   let url = template
     .replace(/{owner}/g, owner)

--- a/src/core/providers/bitbucket.ts
+++ b/src/core/providers/bitbucket.ts
@@ -1,0 +1,26 @@
+import ky from "ky";
+import { BITBUCKET_API_URL, DEFAULT_BRANCH } from "../../types/providers.js";
+
+type BitbucketRepoResponse = {
+  mainbranch: {
+    name: string;
+  };
+};
+
+export const getBitbucketDefaultBranch = async (
+  owner: string,
+  repo: string
+): Promise<string> => {
+  try {
+    const data = await ky
+      .get(`${BITBUCKET_API_URL}/repositories/${owner}/${repo}`)
+      .json<BitbucketRepoResponse>();
+    return data.mainbranch.name;
+  } catch (error) {
+    console.error(
+      `Failed to fetch Bitbucket default branch for ${owner}/${repo}:`,
+      error
+    );
+    return DEFAULT_BRANCH;
+  }
+};

--- a/src/core/providers/detector.ts
+++ b/src/core/providers/detector.ts
@@ -4,5 +4,8 @@ export const detectProvider = (source: string): Provider => {
   if (source.startsWith("gitlab:") || source.includes("gitlab.com")) {
     return "gitlab";
   }
+  if (source.startsWith("bitbucket:") || source.includes("bitbucket.org")) {
+    return "bitbucket";
+  }
   return "github";
 };

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -1,4 +1,4 @@
-export type Provider = "github" | "gitlab";
+export type Provider = "github" | "gitlab" | "bitbucket";
 
 export const GITHUB_API_URL = "https://api.github.com";
 export const GITHUB_ARCHIVE_URL =
@@ -7,5 +7,9 @@ export const GITHUB_ARCHIVE_URL =
 export const GITLAB_API_URL = "https://gitlab.com/api/v4";
 export const GITLAB_ARCHIVE_URL =
   "https://gitlab.com/{owner}/{repo}/-/archive/{branch}.tar.gz";
+
+export const BITBUCKET_API_URL = "https://api.bitbucket.org/2.0";
+export const BITBUCKET_ARCHIVE_URL =
+  "https://bitbucket.org/{owner}/{repo}/get/{branch}.tar.gz";
 
 export const DEFAULT_BRANCH = "main";

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -31,10 +31,14 @@ export const downloadTarball = async (
   });
 
   if (!response.body) {
+    const providerNameMap: Record<Provider, string> = {
+      github: "GitHub",
+      gitlab: "GitLab",
+      bitbucket: "Bitbucket",
+    };
+    const providerName = providerNameMap[provider];
     throw new Error(
-      `Failed to download from ${
-        provider === "gitlab" ? "GitLab" : "GitHub"
-      }: Response body is empty`
+      `Failed to download from ${providerName}: Response body is empty`
     );
   }
 

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -6,14 +6,14 @@ export const parseSource = async (source: string): Promise<RepoInfo> => {
   const provider = detectProvider(source);
 
   let cleanSource = source
-    .replace(/^(github|gitlab):/, "")
-    .replace(/^https?:\/\/(github|gitlab)\.com\//, "");
+    .replace(/^(github|gitlab|bitbucket):/, "")
+    .replace(/^https?:\/\/((github|gitlab)\.com|bitbucket\.org)\//, "");
 
   const parts = cleanSource.split("/");
 
   if (parts.length < 2) {
     throw new Error(
-      "Invalid source format. Use: user/repo, github:user/repo, gitlab:user/repo, or full URL"
+      "Invalid source format. Use: user/repo, github:user/repo, gitlab:user/repo, bitbucket:user/repo, or full URL"
     );
   }
 
@@ -39,7 +39,7 @@ export const parseSource = async (source: string): Promise<RepoInfo> => {
 
   if (!owner || !repo) {
     throw new Error(
-      "Invalid source format. Use: user/repo, github:user/repo, gitlab:user/repo, or full URL"
+      "Invalid source format. Use: user/repo, github:user/repo, gitlab:user/repo, bitbucket:user/repo, or full URL"
     );
   }
 


### PR DESCRIPTION
- Add bitbucket provider type and API constants
- Implement Bitbucket default branch detection
- Update provider detector and parser for bitbucket: prefix and bitbucket.org URLs
- Update archive URL generation for Bitbucket tar.gz downloads
- Update documentation with Bitbucket usage examples

fix #12