### PR TITLE
Add file exclusion feature with Commander integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ baedal user/repo ./output
 # Download specific folder or file
 baedal user/repo/src/components ./components
 
+# Exclude specific files or patterns
+baedal user/repo --exclude "*.test.ts"
+baedal user/repo --exclude "*.md" ".gitignore"
+baedal user/repo ./output --exclude "test/**" "docs/**"
+
 # Explicit GitHub prefix
 baedal github:user/repo
 
@@ -43,6 +48,10 @@ baedal gitlab:user/repo ./output
 # Download specific folder or file
 baedal gitlab:user/repo/src/components ./components
 
+# Exclude specific files or patterns
+baedal gitlab:user/repo --exclude "*.test.ts"
+baedal gitlab:user/repo --exclude "*.test.ts" "*.md"
+
 # Using GitLab URL
 baedal https://gitlab.com/user/repo
 ```
@@ -59,6 +68,10 @@ baedal bitbucket:user/repo ./output
 # Download specific folder or file
 baedal bitbucket:user/repo/src/components ./components
 
+# Exclude specific files or patterns
+baedal bitbucket:user/repo --exclude "*.test.ts"
+baedal bitbucket:user/repo --exclude "*.test.ts" "*.md"
+
 # Using Bitbucket URL
 baedal https://bitbucket.org/user/repo
 ```
@@ -67,6 +80,7 @@ baedal https://bitbucket.org/user/repo
 
 - Download from GitHub, GitLab, and Bitbucket repositories
 - Support for specific folders/files
+- Exclude specific files or patterns using glob patterns
 - Automatic branch detection (main/master)
 - Multiple input formats (prefix, URL, or simple user/repo)
 - Zero configuration
@@ -80,6 +94,16 @@ import { baedal } from "baedal";
 await baedal("user/repo");
 await baedal("user/repo", "./output");
 await baedal("user/repo/src", "./src");
+
+// With exclude option
+await baedal("user/repo", "./output", {
+  exclude: ["*.test.ts", "*.md", "test/**"],
+});
+
+// Exclude without specifying destination (uses current directory)
+await baedal("user/repo", {
+  exclude: ["*.test.ts", "docs/**"],
+});
 
 // GitLab
 await baedal("gitlab:user/repo");

--- a/package.json
+++ b/package.json
@@ -49,10 +49,12 @@
     "commander": "^12.0.0",
     "globby": "^14.0.0",
     "ky": "^1.8.3",
+    "micromatch": "^4.0.8",
     "picocolors": "^1.0.0",
     "tar": "^7.5.1"
   },
   "devDependencies": {
+    "@types/micromatch": "^4.0.9",
     "@types/node": "^20.11.0",
     "@types/tar": "^6.1.13",
     "tsup": "^8.0.0",

--- a/src/core/baedal.ts
+++ b/src/core/baedal.ts
@@ -1,17 +1,21 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import type { DownloadResult } from "../types/index.js";
+import type { BaedalOptions, DownloadResult } from "../types/index.js";
 import { parseSource } from "../utils/parser.js";
 import { downloadTarball } from "../utils/download.js";
 import { extractTarball } from "../utils/extract.js";
 
 export const baedal = async (
   source: string,
-  destination = "."
+  destination: string | BaedalOptions = ".",
+  options?: BaedalOptions
 ): Promise<DownloadResult> => {
+  const destPath = typeof destination === "string" ? destination : ".";
+  const opts = typeof destination === "string" ? options : destination;
+
   const { owner, repo, subdir, provider } = await parseSource(source);
-  const outputPath = resolve(destination);
+  const outputPath = resolve(destPath);
 
   await mkdir(outputPath, { recursive: true });
 
@@ -27,7 +31,8 @@ export const baedal = async (
     const files = await extractTarball(
       tarballPath,
       outputPath,
-      needsSubdirExtraction ? subdir : undefined
+      needsSubdirExtraction ? subdir : undefined,
+      opts?.exclude
     );
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { baedal } from './core/baedal.js';
-export type { DownloadResult } from './types/index.js';
+export { baedal } from "./core/baedal.js";
+export type { BaedalOptions, DownloadResult } from "./types/index.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,3 +11,7 @@ export type RepoInfo = {
   repo: string;
   subdir?: string;
 };
+
+export type BaedalOptions = {
+  exclude?: string[];
+};

--- a/src/utils/extract.ts
+++ b/src/utils/extract.ts
@@ -3,19 +3,44 @@ import { globby } from "globby";
 import { basename, join } from "node:path";
 import { copyFile, cp, mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import micromatch from "micromatch";
 
 export const extractTarball = async (
   tarballPath: string,
   destination: string,
-  subdir?: string
+  subdir?: string,
+  exclude?: string[]
 ): Promise<string[]> => {
+  const shouldExclude =
+    exclude && exclude.length > 0
+      ? (path: string) => micromatch.isMatch(path, exclude)
+      : null;
+
+  const extractOptions = {
+    cwd: destination,
+    file: tarballPath,
+    strip: 1,
+    ...(shouldExclude
+      ? {
+          filter: (path: string) => {
+            // Strip the first path segment since tar strip:1 is applied
+            const strippedPath = path.split("/").slice(1).join("/");
+            return !shouldExclude(strippedPath);
+          },
+        }
+      : {}),
+  };
+
   if (!subdir) {
-    await extract({ cwd: destination, file: tarballPath, strip: 1 });
+    await extract(extractOptions);
   } else {
     const tempExtract = await mkdtemp(join(tmpdir(), "baedal-extract-"));
 
     try {
-      await extract({ cwd: tempExtract, file: tarballPath, strip: 1 });
+      await extract({
+        ...extractOptions,
+        cwd: tempExtract,
+      });
 
       const sourcePath = join(tempExtract, subdir);
       const sourceStats = await stat(sourcePath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,10 +318,22 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz#719df7fb41766bc143369eaa0dd56d8dc87c9958"
   integrity sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==
 
+"@types/braces@*":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.5.tgz#91159f97e516630c7946d8b0d5bf60245986e04c"
+  integrity sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==
+
 "@types/estree@1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/micromatch@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.9.tgz#8e5763a8c1fc7fbf26144d9215a01ab0ff702dbb"
+  integrity sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==
+  dependencies:
+    "@types/braces" "*"
 
 "@types/node@*":
   version "24.7.1"


### PR DESCRIPTION
 Manual argument parsing was unstable and complex

 - Add BaedalOptions type with exclude option
- Replace manual CLI parsing with Commander library for stability
- Support multiple exclude patterns via --exclude flag
- Implement glob-based file filtering in extractTarball
- Update README with exclude usage examples

fix #13