### PR TITLE
Add private repository authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,53 @@ baedal bitbucket:user/repo --exclude "*.test.ts" "*.md"
 baedal https://bitbucket.org/user/repo
 ```
 
+## Private Repository Authentication
+
+Baedal supports downloading from private repositories using authentication tokens.
+
+### Using CLI Flag
+
+```bash
+# GitHub (Personal Access Token)
+baedal user/private-repo --token YOUR_GITHUB_TOKEN
+
+# GitLab (Private Token)
+baedal gitlab:user/private-repo --token YOUR_GITLAB_TOKEN
+
+# Bitbucket (App Password)
+baedal bitbucket:user/private-repo --token YOUR_BITBUCKET_TOKEN
+```
+
+### Using Environment Variables
+
+Set one of the following environment variables:
+
+```bash
+# Generic token (works for all providers)
+export BAEDAL_TOKEN=your_token
+
+# Provider-specific tokens
+export GITHUB_TOKEN=your_github_token
+export GITLAB_TOKEN=your_gitlab_token
+export BITBUCKET_TOKEN=your_bitbucket_token
+
+# Then use baedal normally
+baedal user/private-repo
+```
+
+### Token Generation
+
+- **GitHub**: Create a Personal Access Token at Settings > Developer settings > Personal access tokens
+  - Required scope: `repo` (for private repositories)
+- **GitLab**: Create a Private Token at User Settings > Access Tokens
+  - Required scope: `read_repository`
+- **Bitbucket**: Create an App Password at Personal settings > App passwords
+  - Required permission: `Repositories: Read`
+
 ## Features
 
 - Download from GitHub, GitLab, and Bitbucket repositories
+- Support for private repositories with authentication tokens
 - Support for specific folders/files
 - Exclude specific files or patterns using glob patterns
 - Automatic branch detection (main/master)
@@ -105,15 +149,30 @@ await baedal("user/repo", {
   exclude: ["*.test.ts", "docs/**"],
 });
 
+// Private repository with token
+await baedal("user/private-repo", "./output", {
+  token: process.env.GITHUB_TOKEN,
+});
+
 // GitLab
 await baedal("gitlab:user/repo");
 await baedal("gitlab:user/repo", "./output");
 await baedal("https://gitlab.com/user/repo/src", "./src");
 
+// GitLab private repository
+await baedal("gitlab:user/private-repo", "./output", {
+  token: process.env.GITLAB_TOKEN,
+});
+
 // Bitbucket
 await baedal("bitbucket:user/repo");
 await baedal("bitbucket:user/repo", "./output");
 await baedal("https://bitbucket.org/user/repo/src", "./src");
+
+// Bitbucket private repository
+await baedal("bitbucket:user/private-repo", "./output", {
+  token: process.env.BITBUCKET_TOKEN,
+});
 ```
 
 ## License

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { baedal } from "./core/baedal.js";
 import type { BaedalOptions } from "./types/index.js";
+import { detectProvider } from "./core/providers/detector.js";
 
 const program = new Command();
 
@@ -14,24 +15,51 @@ program
     "-e, --exclude <patterns...>",
     "Exclude files matching patterns (can specify multiple)"
   )
-  .action(async (source: string, destination: string, options: BaedalOptions) => {
-    try {
-      const result = await baedal(source, destination, options);
-      console.log(
-        pc.green(`Downloaded ${result.files.length} files to ${result.path}`)
-      );
-      if (options.exclude && options.exclude.length > 0) {
+  .option(
+    "-t, --token <token>",
+    "Authentication token for private repositories (GitHub: Personal Access Token, GitLab: Private Token, Bitbucket: App Password)"
+  )
+  .action(
+    async (source: string, destination: string, options: BaedalOptions) => {
+      try {
+        // Resolve token based on provider
+        let token = options.token || process.env.BAEDAL_TOKEN;
+        if (!token) {
+          const provider = detectProvider(source);
+          switch (provider) {
+            case "gitlab":
+              token = process.env.GITLAB_TOKEN;
+              break;
+            case "bitbucket":
+              token = process.env.BITBUCKET_TOKEN;
+              break;
+            default:
+              token = process.env.GITHUB_TOKEN;
+              break;
+          }
+        }
+
+        const result = await baedal(source, destination, {
+          ...options,
+          ...(token && { token }),
+        });
+
         console.log(
-          pc.gray(`Excluded patterns: ${options.exclude.join(", ")}`)
+          pc.green(`Downloaded ${result.files.length} files to ${result.path}`)
         );
+        if (options.exclude && options.exclude.length > 0) {
+          console.log(
+            pc.gray(`Excluded patterns: ${options.exclude.join(", ")}`)
+          );
+        }
+      } catch (error) {
+        console.error(
+          pc.red("Error:"),
+          error instanceof Error ? error.message : String(error)
+        );
+        process.exit(1);
       }
-    } catch (error) {
-      console.error(
-        pc.red("Error:"),
-        error instanceof Error ? error.message : String(error)
-      );
-      process.exit(1);
     }
-  });
+  );
 
 program.parse();

--- a/src/core/baedal.ts
+++ b/src/core/baedal.ts
@@ -14,7 +14,10 @@ export const baedal = async (
   const destPath = typeof destination === "string" ? destination : ".";
   const opts = typeof destination === "string" ? options : destination;
 
-  const { owner, repo, subdir, provider } = await parseSource(source);
+  const { owner, repo, subdir, provider } = await parseSource(
+    source,
+    opts?.token
+  );
   const outputPath = resolve(destPath);
 
   await mkdir(outputPath, { recursive: true });
@@ -23,7 +26,14 @@ export const baedal = async (
   const tarballPath = join(tempDir, "archive.tar.gz");
 
   try {
-    await downloadTarball(owner, repo, tarballPath, provider, subdir);
+    await downloadTarball(
+      owner,
+      repo,
+      tarballPath,
+      provider,
+      subdir,
+      opts?.token
+    );
 
     // For GitLab with subdir, the path parameter already filters at server side,
     // so we don't need to filter again during extraction

--- a/src/core/providers/archive.ts
+++ b/src/core/providers/archive.ts
@@ -11,15 +11,16 @@ import { getBitbucketDefaultBranch } from "./bitbucket.js";
 export const getDefaultBranch = async (
   owner: string,
   repo: string,
-  provider: Provider
+  provider: Provider,
+  token?: string
 ): Promise<string> => {
   switch (provider) {
     case "gitlab":
-      return getGitLabDefaultBranch(owner, repo);
+      return getGitLabDefaultBranch(owner, repo, token);
     case "bitbucket":
-      return getBitbucketDefaultBranch(owner, repo);
+      return getBitbucketDefaultBranch(owner, repo, token);
     default:
-      return getGitHubDefaultBranch(owner, repo);
+      return getGitHubDefaultBranch(owner, repo, token);
   }
 };
 

--- a/src/core/providers/bitbucket.ts
+++ b/src/core/providers/bitbucket.ts
@@ -1,5 +1,6 @@
 import ky from "ky";
 import { BITBUCKET_API_URL, DEFAULT_BRANCH } from "../../types/providers.js";
+import { getAuthHeaders } from "../../utils/auth.js";
 
 type BitbucketRepoResponse = {
   mainbranch: {
@@ -9,11 +10,16 @@ type BitbucketRepoResponse = {
 
 export const getBitbucketDefaultBranch = async (
   owner: string,
-  repo: string
+  repo: string,
+  token?: string
 ): Promise<string> => {
   try {
+    const headers = token ? getAuthHeaders("bitbucket", token) : {};
+
     const data = await ky
-      .get(`${BITBUCKET_API_URL}/repositories/${owner}/${repo}`)
+      .get(`${BITBUCKET_API_URL}/repositories/${owner}/${repo}`, {
+        headers,
+      })
       .json<BitbucketRepoResponse>();
     return data.mainbranch.name;
   } catch (error) {

--- a/src/core/providers/github.ts
+++ b/src/core/providers/github.ts
@@ -1,13 +1,19 @@
 import ky from "ky";
 import { GITHUB_API_URL, DEFAULT_BRANCH } from "../../types/providers.js";
+import { getAuthHeaders } from "../../utils/auth.js";
 
 export const getGitHubDefaultBranch = async (
   owner: string,
-  repo: string
+  repo: string,
+  token?: string
 ): Promise<string> => {
   try {
+    const headers = token ? getAuthHeaders("github", token) : {};
+
     const data = await ky
-      .get(`${GITHUB_API_URL}/repos/${owner}/${repo}`)
+      .get(`${GITHUB_API_URL}/repos/${owner}/${repo}`, {
+        headers,
+      })
       .json<{ default_branch: string }>();
     return data.default_branch;
   } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,4 +14,5 @@ export type RepoInfo = {
 
 export type BaedalOptions = {
   exclude?: string[];
+  token?: string;
 };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,15 @@
+import type { Provider } from "../types/providers.js";
+
+export const getAuthHeaders = (
+  provider: Provider,
+  token: string
+): Record<string, string> => {
+  switch (provider) {
+    case "github":
+      return { Authorization: `token ${token}` };
+    case "gitlab":
+      return { "PRIVATE-TOKEN": token };
+    case "bitbucket":
+      return { Authorization: `Bearer ${token}` };
+  }
+};

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -4,15 +4,17 @@ import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
 import type { Provider } from "../types/providers.js";
 import { getDefaultBranch, getArchiveUrl } from "../core/providers/archive.js";
+import { getAuthHeaders } from "./auth.js";
 
 export const downloadTarball = async (
   owner: string,
   repo: string,
   destination: string,
   provider: Provider,
-  subdir?: string
+  subdir?: string,
+  token?: string
 ): Promise<void> => {
-  const branch = await getDefaultBranch(owner, repo, provider);
+  const branch = await getDefaultBranch(owner, repo, provider, token);
   const url = getArchiveUrl({
     branch,
     owner,
@@ -21,13 +23,16 @@ export const downloadTarball = async (
     ...(subdir && { subdir }),
   });
 
+  const headers: Record<string, string> = {
+    Accept: "application/octet-stream, */*",
+    ...(token && getAuthHeaders(provider, token)),
+  };
+
   // GitLab requires mode: 'same-origin' to avoid 406 error due to hotlinking protection
   // Reference: https://github.com/unjs/giget/issues/97
   const response = await ky.get(url, {
     ...(provider === "gitlab" && { mode: "same-origin" as const }),
-    headers: {
-      Accept: "application/octet-stream, */*",
-    },
+    headers,
   });
 
   if (!response.body) {

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -2,7 +2,10 @@ import type { RepoInfo } from "../types/index.js";
 import { detectProvider } from "../core/providers/detector.js";
 import { validateGitLabProject } from "../core/providers/gitlab.js";
 
-export const parseSource = async (source: string): Promise<RepoInfo> => {
+export const parseSource = async (
+  source: string,
+  token?: string
+): Promise<RepoInfo> => {
   const provider = detectProvider(source);
 
   let cleanSource = source
@@ -18,7 +21,7 @@ export const parseSource = async (source: string): Promise<RepoInfo> => {
   }
 
   if (provider === "gitlab" && parts.length > 2) {
-    const { projectPath, subdir } = await validateGitLabProject(parts);
+    const { projectPath, subdir } = await validateGitLabProject(parts, token);
 
     const pathParts = projectPath.split("/");
     const owner = pathParts[0];


### PR DESCRIPTION
Enable downloading from private repositories on GitHub, GitLab, and Bitbucket

- Add --token CLI option with environment variable support (BAEDAL_TOKEN, GITHUB_TOKEN, etc)
- Implement provider-specific authentication headers (GitHub: token, GitLab: PRIVATE-TOKEN, Bitbucket: Bearer)
- Add token generation and usage guide to README

fix #14