### PR TITLE
Add interactive overwrite confirmation with CLI options

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,5 +14,13 @@ export type RepoInfo = {
 
 export type BaedalOptions = {
   exclude?: string[];
+  force?: boolean;
+  noClobber?: boolean;
+  skipExisting?: boolean;
   token?: string;
+};
+
+export type FileCheckResult = {
+  toAdd: string[];
+  toOverwrite: string[];
 };

--- a/src/utils/check-existing.ts
+++ b/src/utils/check-existing.ts
@@ -1,0 +1,25 @@
+import { access, constants } from "node:fs/promises";
+import { join } from "node:path";
+import type { FileCheckResult } from "../types/index.js";
+
+export const checkExistingFiles = async (
+  files: string[],
+  destination: string
+): Promise<FileCheckResult> => {
+  const toOverwrite: string[] = [];
+  const toAdd: string[] = [];
+
+  await Promise.all(
+    files.map(async (file) => {
+      const filePath = join(destination, file);
+      try {
+        await access(filePath, constants.F_OK);
+        toOverwrite.push(file);
+      } catch {
+        toAdd.push(file);
+      }
+    })
+  );
+
+  return { toAdd, toOverwrite };
+};

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,0 +1,56 @@
+import { emitKeypressEvents } from "node:readline";
+
+export const confirmOverwrite = (): Promise<boolean> => {
+  return new Promise((resolve) => {
+    process.stdout.write("\n? Proceed with download? (y/N) ");
+
+    // Set raw mode to read single keypress
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+    process.stdin.resume();
+    emitKeypressEvents(process.stdin);
+
+    const onKeypress = (
+      _char: string,
+      key: { name: string; ctrl?: boolean }
+    ) => {
+      const keyName = key.name.toLowerCase();
+      let confirmed: boolean | null = null;
+      let output = "";
+
+      // Determine outcome based on key press
+      if (key.ctrl && key.name === "c") {
+        confirmed = false;
+        output = "\n";
+      } else if (keyName === "y") {
+        confirmed = true;
+        output = "y\n";
+      } else if (
+        keyName === "n" ||
+        keyName === "return" ||
+        keyName === "escape"
+      ) {
+        confirmed = false;
+        output = "n\n";
+      }
+
+      // Perform side effects only if a decision was made
+      if (confirmed !== null) {
+        cleanup();
+        process.stdout.write(output);
+        resolve(confirmed);
+      }
+    };
+
+    const cleanup = () => {
+      process.stdin.removeListener("keypress", onKeypress);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      process.stdin.pause();
+    };
+
+    process.stdin.on("keypress", onKeypress);
+  });
+};


### PR DESCRIPTION
Prevent accidental file overwrites with user confirmation

- Interactive mode: Show file list and confirm with immediate y/n keypress
- --force: Skip confirmation and overwrite
- --skip-existing: Skip existing files, add new files only
- --no-clobber: Abort if any file would be overwritten

fix #25