### PR TITLE
refactor: introduce ConflictMode Union Type and Adapter Pattern for type safety

### DIFF
--- a/src/cli/adapter.spec.ts
+++ b/src/cli/adapter.spec.ts
@@ -1,0 +1,184 @@
+import { adaptCLIOptions } from "./adapter.js";
+import type { DownloadCLIOptions } from "./types.js";
+
+describe("adaptCLIOptions", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe("ConflictMode conversion", () => {
+    it("should convert force flag to force mode", () => {
+      const cliOptions: DownloadCLIOptions = { force: true };
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.conflictMode).toEqual({ mode: "force" });
+    });
+
+    it("should convert skipExisting flag to skip-existing mode", () => {
+      const cliOptions: DownloadCLIOptions = { skipExisting: true };
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.conflictMode).toEqual({ mode: "skip-existing" });
+    });
+
+    it("should convert noClobber flag to no-clobber mode", () => {
+      const cliOptions: DownloadCLIOptions = { noClobber: true };
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.conflictMode).toEqual({ mode: "no-clobber" });
+    });
+
+    it("should return undefined conflictMode when no flags are set", () => {
+      const cliOptions: DownloadCLIOptions = {};
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.conflictMode).toBeUndefined();
+    });
+  });
+
+  describe("Conflict flag validation", () => {
+    it("should throw error when force and skipExisting are both set", () => {
+      const cliOptions: DownloadCLIOptions = {
+        force: true,
+        skipExisting: true,
+      };
+
+      expect(() => adaptCLIOptions(cliOptions)).toThrow(
+        "Cannot use --force, --skip-existing, and --no-clobber together"
+      );
+    });
+
+    it("should throw error when force and noClobber are both set", () => {
+      const cliOptions: DownloadCLIOptions = {
+        force: true,
+        noClobber: true,
+      };
+
+      expect(() => adaptCLIOptions(cliOptions)).toThrow(
+        "Cannot use --force, --skip-existing, and --no-clobber together"
+      );
+    });
+
+    it("should throw error when skipExisting and noClobber are both set", () => {
+      const cliOptions: DownloadCLIOptions = {
+        noClobber: true,
+        skipExisting: true,
+      };
+
+      expect(() => adaptCLIOptions(cliOptions)).toThrow(
+        "Cannot use --force, --skip-existing, and --no-clobber together"
+      );
+    });
+
+    it("should throw error when all three flags are set", () => {
+      const cliOptions: DownloadCLIOptions = {
+        force: true,
+        noClobber: true,
+        skipExisting: true,
+      };
+
+      expect(() => adaptCLIOptions(cliOptions)).toThrow(
+        "Cannot use --force, --skip-existing, and --no-clobber together"
+      );
+    });
+  });
+
+  describe("Token resolution", () => {
+    it("should use CLI token when provided", () => {
+      const cliOptions: DownloadCLIOptions = { token: "cli-token" };
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.token).toBe("cli-token");
+    });
+
+    it("should use GITHUB_TOKEN when CLI token is not provided", () => {
+      process.env.GITHUB_TOKEN = "github-token";
+      const cliOptions: DownloadCLIOptions = {};
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.token).toBe("github-token");
+    });
+
+    it("should use BAEDAL_TOKEN when neither CLI token nor GITHUB_TOKEN is provided", () => {
+      process.env.BAEDAL_TOKEN = "baedal-token";
+      const cliOptions: DownloadCLIOptions = {};
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.token).toBe("baedal-token");
+    });
+
+    it("should prioritize CLI token over environment variables", () => {
+      process.env.GITHUB_TOKEN = "github-token";
+      process.env.BAEDAL_TOKEN = "baedal-token";
+      const cliOptions: DownloadCLIOptions = { token: "cli-token" };
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.token).toBe("cli-token");
+    });
+
+    it("should prioritize GITHUB_TOKEN over BAEDAL_TOKEN", () => {
+      process.env.GITHUB_TOKEN = "github-token";
+      process.env.BAEDAL_TOKEN = "baedal-token";
+      const cliOptions: DownloadCLIOptions = {};
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.token).toBe("github-token");
+    });
+
+    it("should return undefined token when none are provided", () => {
+      const cliOptions: DownloadCLIOptions = {};
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.token).toBeUndefined();
+    });
+  });
+
+  describe("Exclude patterns", () => {
+    it("should include exclude patterns when provided", () => {
+      const cliOptions: DownloadCLIOptions = {
+        exclude: ["*.test.ts", "*.spec.ts"],
+      };
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.exclude).toEqual(["*.test.ts", "*.spec.ts"]);
+    });
+
+    it("should not include exclude field when not provided", () => {
+      const cliOptions: DownloadCLIOptions = {};
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result.exclude).toBeUndefined();
+    });
+  });
+
+  describe("Complete options", () => {
+    it("should convert all options correctly", () => {
+      process.env.GITHUB_TOKEN = "env-token";
+      const cliOptions: DownloadCLIOptions = {
+        exclude: ["*.log"],
+        force: true,
+        token: "cli-token",
+      };
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(result).toEqual({
+        conflictMode: { mode: "force" },
+        exclude: ["*.log"],
+        token: "cli-token",
+      });
+    });
+
+    it("should only include defined values", () => {
+      const cliOptions: DownloadCLIOptions = {};
+      const result = adaptCLIOptions(cliOptions);
+
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+  });
+});

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -1,0 +1,34 @@
+import type { BaedalOptions, ConflictMode } from "../types/index.js";
+import type { DownloadCLIOptions } from "./types.js";
+
+const validateConflictFlags = (options: DownloadCLIOptions): void => {
+  const conflictFlags = [options.force, options.skipExisting, options.noClobber].filter(Boolean);
+
+  if (conflictFlags.length > 1) {
+    throw new Error("Cannot use --force, --skip-existing, and --no-clobber together");
+  }
+};
+
+const resolveConflictMode = (options: DownloadCLIOptions): ConflictMode | undefined => {
+  if (options.force) return { mode: "force" };
+  if (options.skipExisting) return { mode: "skip-existing" };
+  if (options.noClobber) return { mode: "no-clobber" };
+  return undefined; // Library defaults to interactive
+};
+
+const resolveToken = (cliToken: string | undefined): string | undefined => {
+  return cliToken ?? process.env.GITHUB_TOKEN ?? process.env.BAEDAL_TOKEN;
+};
+
+export const adaptCLIOptions = (cliOptions: DownloadCLIOptions): BaedalOptions => {
+  validateConflictFlags(cliOptions);
+
+  const conflictMode = resolveConflictMode(cliOptions);
+  const token = resolveToken(cliOptions.token);
+
+  return {
+    ...(conflictMode && { conflictMode }),
+    ...(cliOptions.exclude && { exclude: cliOptions.exclude }),
+    ...(token && { token }),
+  };
+};

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,7 @@
+export type DownloadCLIOptions = {
+  exclude?: string[];
+  force?: boolean;
+  noClobber?: boolean;
+  skipExisting?: boolean;
+  token?: string;
+};

--- a/src/core/baedal.ts
+++ b/src/core/baedal.ts
@@ -40,15 +40,17 @@ export const baedal = async (
     // Check for existing files
     const { toAdd, toOverwrite } = await checkExistingFiles(fileList, outputPath);
 
+    const resolvedMode = opts?.conflictMode?.mode ?? "interactive";
+
     // Handle different modes
     if (toOverwrite.length > 0) {
-      if (opts?.noClobber) {
+      if (resolvedMode === "no-clobber") {
         throw new Error(
           `Operation aborted as per --no-clobber: ${toOverwrite.length} file(s) already exist.`
         );
       }
 
-      if (opts?.skipExisting) {
+      if (resolvedMode === "skip-existing") {
         // Only extract new files by adding existing files to exclude list
         const excludePatterns = [...(opts?.exclude ?? []), ...toOverwrite];
 
@@ -65,8 +67,8 @@ export const baedal = async (
         };
       }
 
-      // Interactive mode (default when not --force)
-      if (!opts?.force) {
+      // Interactive mode (default when not force)
+      if (resolvedMode === "interactive") {
         console.log(pc.yellow(`\n⚠️  The following files will be overwritten:`));
         toOverwrite.forEach((file) => {
           console.log(pc.yellow(`  - ${file}`));

--- a/src/types/index.spec.ts
+++ b/src/types/index.spec.ts
@@ -1,0 +1,48 @@
+import type { BaedalOptions, ConflictMode } from "./index.js";
+
+describe("ConflictMode", () => {
+  test("should accept force mode", () => {
+    const mode: ConflictMode = { mode: "force" };
+    expect(mode.mode).toBe("force");
+  });
+
+  test("should accept skip-existing mode", () => {
+    const mode: ConflictMode = { mode: "skip-existing" };
+    expect(mode.mode).toBe("skip-existing");
+  });
+
+  test("should accept no-clobber mode", () => {
+    const mode: ConflictMode = { mode: "no-clobber" };
+    expect(mode.mode).toBe("no-clobber");
+  });
+
+  test("should accept interactive mode", () => {
+    const mode: ConflictMode = { mode: "interactive" };
+    expect(mode.mode).toBe("interactive");
+  });
+});
+
+describe("BaedalOptions", () => {
+  test("should accept conflictMode field", () => {
+    const options: BaedalOptions = {
+      conflictMode: { mode: "force" },
+    };
+    expect(options.conflictMode?.mode).toBe("force");
+  });
+
+  test("should accept all optional fields", () => {
+    const options: BaedalOptions = {
+      conflictMode: { mode: "skip-existing" },
+      exclude: ["*.log"],
+      token: "ghp_test123",
+    };
+    expect(options.conflictMode?.mode).toBe("skip-existing");
+    expect(options.exclude).toEqual(["*.log"]);
+    expect(options.token).toBe("ghp_test123");
+  });
+
+  test("should allow empty options object", () => {
+    const options: BaedalOptions = {};
+    expect(options).toEqual({});
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,11 +12,15 @@ export type RepoInfo = {
   subdir?: string;
 };
 
+export type ConflictMode =
+  | { mode: "force" }
+  | { mode: "skip-existing" }
+  | { mode: "no-clobber" }
+  | { mode: "interactive" };
+
 export type BaedalOptions = {
+  conflictMode?: ConflictMode;
   exclude?: string[];
-  force?: boolean;
-  noClobber?: boolean;
-  skipExisting?: boolean;
   token?: string;
 };
 


### PR DESCRIPTION
Enforce mutually exclusive options via type system and separate CLI/Library layers

- Define ConflictMode Union Type to ensure mutually exclusive options at type level
- Apply Adapter Pattern to separate CLI (boolean flags) and Library (Union Type) layers
- Reduce CLI action handler code from 40 lines to 10 lines (75% reduction)
- Extract adapter logic into testable pure functions (18 tests added)
- Follow TypeScript skill principles (Arrow functions, Immutability)

Note: This introduces breaking changes to the Library API (removed force/skipExisting/noClobber fields from BaedalOptions), but BREAKING CHANGE footer is omitted as the project is in MVP stage and not ready for major version bump. CLI users are unaffected.

fix #65