### PR TITLE
refactor: rename download command to pull and unify related types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,29 +18,32 @@ pnpm add -g baedal
 
 ```bash
 # Download entire repository
-baedal user/repo
+baedal pull user/repo
 
 # Download to specific directory
-baedal user/repo ./output
+baedal pull user/repo ./output
 
 # Download specific folder or file
-baedal user/repo/src/components ./components
+baedal pull user/repo/src/components ./components
 
 # Exclude specific files or patterns
-baedal user/repo --exclude "*.test.ts"
-baedal user/repo --exclude "*.md" ".gitignore"
-baedal user/repo ./output --exclude "test/**" "docs/**"
+baedal pull user/repo --exclude "*.test.ts"
+baedal pull user/repo --exclude "*.md" ".gitignore"
+baedal pull user/repo ./output --exclude "test/**" "docs/**"
 
 # File conflict handling
-baedal user/repo --force                # Force overwrite without confirmation
-baedal user/repo --skip-existing        # Skip existing files, only add new files
-baedal user/repo --no-clobber          # Abort if any file would be overwritten
+baedal pull user/repo --force                # Force overwrite without confirmation
+baedal pull user/repo --skip-existing        # Skip existing files, only add new files
+baedal pull user/repo --no-clobber          # Abort if any file would be overwritten
 
 # Explicit GitHub prefix
-baedal github:user/repo
+baedal pull github:user/repo
 
 # Using GitHub URL
-baedal https://github.com/user/repo
+baedal pull https://github.com/user/repo
+
+# Note: 'pull' is the default command, so 'baedal user/repo' also works
+baedal user/repo
 ```
 
 ## Private Repository Authentication
@@ -50,7 +53,7 @@ Baedal supports downloading from private repositories using GitHub authenticatio
 ### Using CLI Flag
 
 ```bash
-baedal user/private-repo --token YOUR_GITHUB_TOKEN
+baedal pull user/private-repo --token YOUR_GITHUB_TOKEN
 ```
 
 ### Using Environment Variables
@@ -62,7 +65,7 @@ export GITHUB_TOKEN=your_github_token
 export BAEDAL_TOKEN=your_token
 
 # Then use baedal normally
-baedal user/private-repo
+baedal pull user/private-repo
 ```
 
 ### Token Generation

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint": "eslint \"src/**/*.ts\"",
     "prepare": "husky",
     "prepublishOnly": "pnpm build",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@octokit/rest": "22.0.1",

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,0 +1,57 @@
+import { program } from "./cli.js";
+
+describe("CLI Command Structure", () => {
+  describe("pull command", () => {
+    it("should be registered as default command", () => {
+      const pullCommand = program.commands.find((cmd) => cmd.name() === "pull");
+      expect(pullCommand).toBeDefined();
+    });
+
+    it("should accept source and optional destination arguments", () => {
+      const pullCommand = program.commands.find((cmd) => cmd.name() === "pull");
+      expect(pullCommand).toBeDefined();
+      expect(pullCommand?.registeredArguments).toHaveLength(2);
+      if (pullCommand?.registeredArguments) {
+        expect(pullCommand.registeredArguments[0]?.required).toBe(true);
+        expect(pullCommand.registeredArguments[1]?.required).toBe(false);
+      }
+    });
+
+    it("should support conflict mode options", () => {
+      const pullCommand = program.commands.find((cmd) => cmd.name() === "pull");
+      expect(pullCommand?.options.map((opt) => opt.long)).toContain("--force");
+      expect(pullCommand?.options.map((opt) => opt.long)).toContain("--skip-existing");
+      expect(pullCommand?.options.map((opt) => opt.long)).toContain("--no-clobber");
+    });
+
+    it("should support exclude and token options", () => {
+      const pullCommand = program.commands.find((cmd) => cmd.name() === "pull");
+      expect(pullCommand?.options.map((opt) => opt.long)).toContain("--exclude");
+      expect(pullCommand?.options.map((opt) => opt.long)).toContain("--token");
+    });
+  });
+
+  describe("push command", () => {
+    it("should be registered with sync-name argument", () => {
+      const pushCommand = program.commands.find((cmd) => cmd.name() === "push");
+      expect(pushCommand).toBeDefined();
+      expect(pushCommand?.registeredArguments).toHaveLength(1);
+      if (pushCommand?.registeredArguments) {
+        expect(pushCommand.registeredArguments[0]?.name()).toBe("sync-name");
+      }
+    });
+  });
+
+  describe("push:init command", () => {
+    it("should be registered with sync-name argument", () => {
+      const pushInitCommand = program.commands.find((cmd) => cmd.name() === "push:init");
+      expect(pushInitCommand).toBeDefined();
+      expect(pushInitCommand?.registeredArguments).toHaveLength(1);
+    });
+
+    it("should support force option", () => {
+      const pushInitCommand = program.commands.find((cmd) => cmd.name() === "push:init");
+      expect(pushInitCommand?.options.map((opt) => opt.long)).toContain("--force");
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import pc from "picocolors";
 import { adaptCLIOptions } from "./cli/adapter.js";
-import type { DownloadCLIOptions } from "./cli/types.js";
+import type { PullCLIOptions } from "./cli/types.js";
 import { baedal } from "./core/baedal.js";
 import { executePush, initPushConfig, loadPushConfig, printInitSuccess } from "./push/index.js";
 import type { PushInitCLIOptions } from "./push/types.js";
@@ -15,9 +15,8 @@ const handleError = (error: unknown): never => {
 
 program.name("baedal");
 
-// TODO: default -> pull
 program
-  .command("download", { isDefault: true })
+  .command("pull", { isDefault: true })
   .description("Download files/folders from Git repositories")
   .argument("<source>", "Repository source (user/repo or URL)")
   .argument("[destination]", "Destination directory", ".")
@@ -29,7 +28,7 @@ program
   .option("-f, --force", "Force overwrite without confirmation")
   .option("-s, --skip-existing", "Skip existing files, only add new files")
   .option("-n, --no-clobber", "Abort if any file would be overwritten")
-  .action(async (source: string, destination: string, cliOptions: DownloadCLIOptions) => {
+  .action(async (source: string, destination: string, cliOptions: PullCLIOptions) => {
     try {
       const baedalOptions = adaptCLIOptions(cliOptions);
 
@@ -79,4 +78,8 @@ program
     }
   });
 
-program.parse();
+export { program };
+
+if (process.env.NODE_ENV !== "test") {
+  program.parse();
+}

--- a/src/cli/adapter.spec.ts
+++ b/src/cli/adapter.spec.ts
@@ -1,5 +1,5 @@
 import { adaptCLIOptions } from "./adapter.js";
-import type { DownloadCLIOptions } from "./types.js";
+import type { PullCLIOptions } from "./types.js";
 
 describe("adaptCLIOptions", () => {
   const originalEnv = process.env;
@@ -14,28 +14,28 @@ describe("adaptCLIOptions", () => {
 
   describe("ConflictMode conversion", () => {
     it("should convert force flag to force mode", () => {
-      const cliOptions: DownloadCLIOptions = { force: true };
+      const cliOptions: PullCLIOptions = { force: true };
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.conflictMode).toEqual({ mode: "force" });
     });
 
     it("should convert skipExisting flag to skip-existing mode", () => {
-      const cliOptions: DownloadCLIOptions = { skipExisting: true };
+      const cliOptions: PullCLIOptions = { skipExisting: true };
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.conflictMode).toEqual({ mode: "skip-existing" });
     });
 
     it("should convert noClobber flag to no-clobber mode", () => {
-      const cliOptions: DownloadCLIOptions = { noClobber: true };
+      const cliOptions: PullCLIOptions = { noClobber: true };
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.conflictMode).toEqual({ mode: "no-clobber" });
     });
 
     it("should return undefined conflictMode when no flags are set", () => {
-      const cliOptions: DownloadCLIOptions = {};
+      const cliOptions: PullCLIOptions = {};
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.conflictMode).toBeUndefined();
@@ -44,7 +44,7 @@ describe("adaptCLIOptions", () => {
 
   describe("Conflict flag validation", () => {
     it("should throw error when force and skipExisting are both set", () => {
-      const cliOptions: DownloadCLIOptions = {
+      const cliOptions: PullCLIOptions = {
         force: true,
         skipExisting: true,
       };
@@ -55,7 +55,7 @@ describe("adaptCLIOptions", () => {
     });
 
     it("should throw error when force and noClobber are both set", () => {
-      const cliOptions: DownloadCLIOptions = {
+      const cliOptions: PullCLIOptions = {
         force: true,
         noClobber: true,
       };
@@ -66,7 +66,7 @@ describe("adaptCLIOptions", () => {
     });
 
     it("should throw error when skipExisting and noClobber are both set", () => {
-      const cliOptions: DownloadCLIOptions = {
+      const cliOptions: PullCLIOptions = {
         noClobber: true,
         skipExisting: true,
       };
@@ -77,7 +77,7 @@ describe("adaptCLIOptions", () => {
     });
 
     it("should throw error when all three flags are set", () => {
-      const cliOptions: DownloadCLIOptions = {
+      const cliOptions: PullCLIOptions = {
         force: true,
         noClobber: true,
         skipExisting: true,
@@ -91,7 +91,7 @@ describe("adaptCLIOptions", () => {
 
   describe("Token resolution", () => {
     it("should use CLI token when provided", () => {
-      const cliOptions: DownloadCLIOptions = { token: "cli-token" };
+      const cliOptions: PullCLIOptions = { token: "cli-token" };
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.token).toBe("cli-token");
@@ -99,7 +99,7 @@ describe("adaptCLIOptions", () => {
 
     it("should use GITHUB_TOKEN when CLI token is not provided", () => {
       process.env.GITHUB_TOKEN = "github-token";
-      const cliOptions: DownloadCLIOptions = {};
+      const cliOptions: PullCLIOptions = {};
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.token).toBe("github-token");
@@ -107,7 +107,7 @@ describe("adaptCLIOptions", () => {
 
     it("should use BAEDAL_TOKEN when neither CLI token nor GITHUB_TOKEN is provided", () => {
       process.env.BAEDAL_TOKEN = "baedal-token";
-      const cliOptions: DownloadCLIOptions = {};
+      const cliOptions: PullCLIOptions = {};
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.token).toBe("baedal-token");
@@ -116,7 +116,7 @@ describe("adaptCLIOptions", () => {
     it("should prioritize CLI token over environment variables", () => {
       process.env.GITHUB_TOKEN = "github-token";
       process.env.BAEDAL_TOKEN = "baedal-token";
-      const cliOptions: DownloadCLIOptions = { token: "cli-token" };
+      const cliOptions: PullCLIOptions = { token: "cli-token" };
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.token).toBe("cli-token");
@@ -125,14 +125,14 @@ describe("adaptCLIOptions", () => {
     it("should prioritize GITHUB_TOKEN over BAEDAL_TOKEN", () => {
       process.env.GITHUB_TOKEN = "github-token";
       process.env.BAEDAL_TOKEN = "baedal-token";
-      const cliOptions: DownloadCLIOptions = {};
+      const cliOptions: PullCLIOptions = {};
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.token).toBe("github-token");
     });
 
     it("should return undefined token when none are provided", () => {
-      const cliOptions: DownloadCLIOptions = {};
+      const cliOptions: PullCLIOptions = {};
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.token).toBeUndefined();
@@ -141,7 +141,7 @@ describe("adaptCLIOptions", () => {
 
   describe("Exclude patterns", () => {
     it("should include exclude patterns when provided", () => {
-      const cliOptions: DownloadCLIOptions = {
+      const cliOptions: PullCLIOptions = {
         exclude: ["*.test.ts", "*.spec.ts"],
       };
       const result = adaptCLIOptions(cliOptions);
@@ -150,7 +150,7 @@ describe("adaptCLIOptions", () => {
     });
 
     it("should not include exclude field when not provided", () => {
-      const cliOptions: DownloadCLIOptions = {};
+      const cliOptions: PullCLIOptions = {};
       const result = adaptCLIOptions(cliOptions);
 
       expect(result.exclude).toBeUndefined();
@@ -160,7 +160,7 @@ describe("adaptCLIOptions", () => {
   describe("Complete options", () => {
     it("should convert all options correctly", () => {
       process.env.GITHUB_TOKEN = "env-token";
-      const cliOptions: DownloadCLIOptions = {
+      const cliOptions: PullCLIOptions = {
         exclude: ["*.log"],
         force: true,
         token: "cli-token",
@@ -175,7 +175,7 @@ describe("adaptCLIOptions", () => {
     });
 
     it("should only include defined values", () => {
-      const cliOptions: DownloadCLIOptions = {};
+      const cliOptions: PullCLIOptions = {};
       const result = adaptCLIOptions(cliOptions);
 
       expect(Object.keys(result)).toHaveLength(0);

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -1,7 +1,7 @@
 import type { BaedalOptions, ConflictMode } from "../types/index.js";
-import type { DownloadCLIOptions } from "./types.js";
+import type { PullCLIOptions } from "./types.js";
 
-const validateConflictFlags = (options: DownloadCLIOptions): void => {
+const validateConflictFlags = (options: PullCLIOptions): void => {
   const conflictFlags = [options.force, options.skipExisting, options.noClobber].filter(Boolean);
 
   if (conflictFlags.length > 1) {
@@ -9,7 +9,7 @@ const validateConflictFlags = (options: DownloadCLIOptions): void => {
   }
 };
 
-const resolveConflictMode = (options: DownloadCLIOptions): ConflictMode | undefined => {
+const resolveConflictMode = (options: PullCLIOptions): ConflictMode | undefined => {
   if (options.force) return { mode: "force" };
   if (options.skipExisting) return { mode: "skip-existing" };
   if (options.noClobber) return { mode: "no-clobber" };
@@ -20,7 +20,7 @@ const resolveToken = (cliToken: string | undefined): string | undefined => {
   return cliToken ?? process.env.GITHUB_TOKEN ?? process.env.BAEDAL_TOKEN;
 };
 
-export const adaptCLIOptions = (cliOptions: DownloadCLIOptions): BaedalOptions => {
+export const adaptCLIOptions = (cliOptions: PullCLIOptions): BaedalOptions => {
   validateConflictFlags(cliOptions);
 
   const conflictMode = resolveConflictMode(cliOptions);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,4 +1,4 @@
-export type DownloadCLIOptions = {
+export type PullCLIOptions = {
   exclude?: string[];
   force?: boolean;
   noClobber?: boolean;

--- a/src/core/baedal.ts
+++ b/src/core/baedal.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import pc from "picocolors";
-import type { BaedalOptions, DownloadResult } from "../types/index.js";
+import type { BaedalOptions, PullResult } from "../types/index.js";
 import { checkExistingFiles } from "../utils/check-existing.js";
 import { downloadTarball } from "../utils/download.js";
 import { extractTarball, getFileListFromTarball } from "../utils/extract.js";
@@ -13,7 +13,7 @@ export const baedal = async (
   source: string,
   destination: string | BaedalOptions = ".",
   options?: BaedalOptions
-): Promise<DownloadResult> => {
+): Promise<PullResult> => {
   const destPath = typeof destination === "string" ? destination : ".";
   const opts = typeof destination === "string" ? options : destination;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { baedal } from "./core/baedal.js";
-export type { BaedalOptions, DownloadResult } from "./types/index.js";
+export type { BaedalOptions, PullResult } from "./types/index.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import type { Provider } from "./providers.js";
 
-export type DownloadResult = {
+export type PullResult = {
   files: string[];
   path: string;
 };


### PR DESCRIPTION
- CLI command: download → pull (set as default)
- CLI types: DownloadCLIOptions → PullCLIOptions
- Public API types: DownloadResult → PullResult
- Update README examples to baedal pull format
- Remove TODO comment (cli.ts:17)

Note: This introduces breaking changes (removed 'download' command and renamed DownloadResult to PullResult), but BREAKING CHANGE footer is omitted as the project is in MVP stage with minimal users.

fix #66