### PR TITLE
refactor: add NetworkError and ValidationError classes

### DIFF
--- a/src/internal/errors/index.ts
+++ b/src/internal/errors/index.ts
@@ -1,2 +1,4 @@
 export { BaseError } from "./base.js";
 export { ExtractionError, FileSystemError } from "./filesystem.js";
+export { GitHubAPIError, NetworkError } from "./network.js";
+export { ConfigError, ValidationError } from "./validation.js";

--- a/src/internal/errors/network.spec.ts
+++ b/src/internal/errors/network.spec.ts
@@ -1,0 +1,77 @@
+import { BaseError } from "./base.js";
+import { GitHubAPIError, NetworkError } from "./network.js";
+
+describe("NetworkError", () => {
+  it("should create NetworkError with message only", () => {
+    const error = new NetworkError("Network connection failed");
+
+    expect(error).toBeInstanceOf(NetworkError);
+    expect(error).toBeInstanceOf(BaseError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("Network connection failed");
+    expect(error.code).toBe("NETWORK_ERROR");
+    expect(error.name).toBe("NetworkError");
+    expect(error.statusCode).toBeUndefined();
+    expect(error.url).toBeUndefined();
+  });
+
+  it("should create NetworkError with status code and URL", () => {
+    const error = new NetworkError("Request failed", 404, "https://api.github.com/repos/test/repo");
+
+    expect(error.message).toBe("Request failed");
+    expect(error.code).toBe("NETWORK_ERROR");
+    expect(error.statusCode).toBe(404);
+    expect(error.url).toBe("https://api.github.com/repos/test/repo");
+  });
+
+  it("should preserve stack trace", () => {
+    const error = new NetworkError("Test error");
+
+    expect(error.stack).toBeDefined();
+    expect(error.stack).toContain("NetworkError");
+  });
+});
+
+describe("GitHubAPIError", () => {
+  it("should create GitHubAPIError with message only", () => {
+    const error = new GitHubAPIError("GitHub API rate limit exceeded");
+
+    expect(error).toBeInstanceOf(GitHubAPIError);
+    expect(error).toBeInstanceOf(NetworkError);
+    expect(error).toBeInstanceOf(BaseError);
+    expect(error.message).toBe("GitHub API rate limit exceeded");
+    expect(error.code).toBe("GITHUB_API_ERROR");
+    expect(error.name).toBe("GitHubAPIError");
+    expect(error.statusCode).toBeUndefined();
+    expect(error.url).toBeUndefined();
+    expect(error.response).toBeUndefined();
+  });
+
+  it("should create GitHubAPIError with all parameters", () => {
+    const responseData = {
+      documentation_url:
+        "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting",
+      message: "API rate limit exceeded",
+    };
+
+    const error = new GitHubAPIError(
+      "Rate limit exceeded",
+      403,
+      "https://api.github.com/repos/test/repo",
+      responseData
+    );
+
+    expect(error.message).toBe("Rate limit exceeded");
+    expect(error.code).toBe("GITHUB_API_ERROR");
+    expect(error.statusCode).toBe(403);
+    expect(error.url).toBe("https://api.github.com/repos/test/repo");
+    expect(error.response).toEqual(responseData);
+  });
+
+  it("should inherit NetworkError properties", () => {
+    const error = new GitHubAPIError("Not found", 404, "https://api.github.com");
+
+    expect(error.statusCode).toBe(404);
+    expect(error.url).toBe("https://api.github.com");
+  });
+});

--- a/src/internal/errors/network.ts
+++ b/src/internal/errors/network.ts
@@ -1,0 +1,24 @@
+import { BaseError } from "./base.js";
+
+export class NetworkError extends BaseError {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly url?: string
+  ) {
+    super(message, "NETWORK_ERROR");
+  }
+}
+
+export class GitHubAPIError extends NetworkError {
+  public override readonly code = "GITHUB_API_ERROR";
+
+  constructor(
+    message: string,
+    statusCode?: number,
+    url?: string,
+    public readonly response?: unknown
+  ) {
+    super(message, statusCode, url);
+  }
+}

--- a/src/internal/errors/validation.spec.ts
+++ b/src/internal/errors/validation.spec.ts
@@ -1,0 +1,79 @@
+import { BaseError } from "./base.js";
+import { ConfigError, ValidationError } from "./validation.js";
+
+describe("ValidationError", () => {
+  it("should create ValidationError with message only", () => {
+    const error = new ValidationError("Invalid input");
+
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error).toBeInstanceOf(BaseError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("Invalid input");
+    expect(error.code).toBe("VALIDATION_ERROR");
+    expect(error.name).toBe("ValidationError");
+    expect(error.field).toBeUndefined();
+    expect(error.value).toBeUndefined();
+  });
+
+  it("should create ValidationError with field and value", () => {
+    const error = new ValidationError("Source must be a non-empty string", "source", "");
+
+    expect(error.message).toBe("Source must be a non-empty string");
+    expect(error.code).toBe("VALIDATION_ERROR");
+    expect(error.field).toBe("source");
+    expect(error.value).toBe("");
+  });
+
+  it("should handle complex value types", () => {
+    const complexValue = { force: true, skipExisting: true };
+    const error = new ValidationError("Conflicting options", "options", complexValue);
+
+    expect(error.field).toBe("options");
+    expect(error.value).toEqual(complexValue);
+  });
+
+  it("should preserve stack trace", () => {
+    const error = new ValidationError("Test error");
+
+    expect(error.stack).toBeDefined();
+    expect(error.stack).toContain("ValidationError");
+  });
+});
+
+describe("ConfigError", () => {
+  it("should create ConfigError with message only", () => {
+    const error = new ConfigError("Missing required configuration");
+
+    expect(error).toBeInstanceOf(ConfigError);
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error).toBeInstanceOf(BaseError);
+    expect(error.message).toBe("Missing required configuration");
+    expect(error.code).toBe("CONFIG_ERROR");
+    expect(error.name).toBe("ConfigError");
+    expect(error.field).toBeUndefined();
+    expect(error.value).toBeUndefined();
+  });
+
+  it("should create ConfigError with field and value", () => {
+    const error = new ConfigError("Invalid repository format", "repository", "invalid/repo/path");
+
+    expect(error.message).toBe("Invalid repository format");
+    expect(error.code).toBe("CONFIG_ERROR");
+    expect(error.field).toBe("repository");
+    expect(error.value).toBe("invalid/repo/path");
+  });
+
+  it("should inherit ValidationError properties", () => {
+    const error = new ConfigError("Token is required for private repositories", "token", undefined);
+
+    expect(error.field).toBe("token");
+    expect(error.value).toBeUndefined();
+  });
+
+  it("should handle null values", () => {
+    const error = new ConfigError("Output path cannot be null", "outputPath", null);
+
+    expect(error.field).toBe("outputPath");
+    expect(error.value).toBeNull();
+  });
+});

--- a/src/internal/errors/validation.ts
+++ b/src/internal/errors/validation.ts
@@ -1,0 +1,19 @@
+import { BaseError } from "./base.js";
+
+export class ValidationError extends BaseError {
+  constructor(
+    message: string,
+    public readonly field?: string,
+    public readonly value?: unknown
+  ) {
+    super(message, "VALIDATION_ERROR");
+  }
+}
+
+export class ConfigError extends ValidationError {
+  public override readonly code = "CONFIG_ERROR";
+
+  constructor(message: string, field?: string, value?: unknown) {
+    super(message, field, value);
+  }
+}


### PR DESCRIPTION
Add error classes for handling network request failures and input validation failures

- NetworkError: handles HTTP request failures (includes statusCode, url)
- GitHubAPIError: GitHub API-specific error (includes response data)
- ValidationError: handles input validation failures (includes field, value)
- ConfigError: configuration validation-specific error
- Add 16 unit tests for error classes (7 in network.spec.ts, 9 in validation.spec.ts)

fix #71