### PR TITLE
test: improve coverage by 12% with integration tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,10 @@ export default {
     '^.+\\.ts$': [
       'ts-jest',
       {
+        diagnostics: {
+          ignoreCodes: [2307, 2571, 7016],
+        },
+        isolatedModules: false,
         useESM: true,
       },
     ],

--- a/justfile
+++ b/justfile
@@ -59,5 +59,5 @@ release:
     @echo ""
     @echo "📊 Check progress: https://github.com/KubrickCode/baedal/actions"
 
-test:
-    pnpm test
+test *args:
+    pnpm test {{ args }}

--- a/src/internal/utils/check-existing.spec.ts
+++ b/src/internal/utils/check-existing.spec.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkExistingFiles } from "./check-existing.js";
+
+describe("checkExistingFiles - Integration Test", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "baedal-check-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { force: true, recursive: true });
+  });
+
+  it("should identify existing and new files", async () => {
+    await writeFile(join(testDir, "existing.ts"), "content");
+    await writeFile(join(testDir, "another.ts"), "content");
+
+    const result = await checkExistingFiles(
+      ["existing.ts", "another.ts", "new.ts", "new2.ts"],
+      testDir
+    );
+
+    expect(result.toOverwrite.sort()).toEqual(["another.ts", "existing.ts"]);
+    expect(result.toAdd.sort()).toEqual(["new.ts", "new2.ts"]);
+  });
+
+  it("should handle all files as new when none exist", async () => {
+    const result = await checkExistingFiles(["file1.ts", "file2.ts"], testDir);
+
+    expect(result.toOverwrite).toEqual([]);
+    expect(result.toAdd.sort()).toEqual(["file1.ts", "file2.ts"].sort());
+  });
+
+  it("should handle nested paths", async () => {
+    await mkdir(join(testDir, "src/components"), { recursive: true });
+    await writeFile(join(testDir, "src/components/Button.tsx"), "code");
+
+    const result = await checkExistingFiles(
+      ["src/components/Button.tsx", "src/components/Input.tsx"],
+      testDir
+    );
+
+    expect(result.toOverwrite).toEqual(["src/components/Button.tsx"]);
+    expect(result.toAdd).toEqual(["src/components/Input.tsx"]);
+  });
+
+  it("should handle empty file list", async () => {
+    const result = await checkExistingFiles([], testDir);
+
+    expect(result.toOverwrite).toEqual([]);
+    expect(result.toAdd).toEqual([]);
+  });
+});

--- a/src/pkg/pull/archive.spec.ts
+++ b/src/pkg/pull/archive.spec.ts
@@ -1,0 +1,47 @@
+import { getArchiveUrl } from "./archive.js";
+
+describe("getArchiveUrl", () => {
+  it("should generate GitHub tarball URL", () => {
+    const url = getArchiveUrl({
+      branch: "main",
+      owner: "octocat",
+      provider: "github",
+      repo: "hello-world",
+    });
+
+    expect(url).toBe("https://codeload.github.com/octocat/hello-world/tar.gz/main");
+  });
+
+  it("should handle different branches", () => {
+    const url = getArchiveUrl({
+      branch: "develop",
+      owner: "user",
+      provider: "github",
+      repo: "project",
+    });
+
+    expect(url).toBe("https://codeload.github.com/user/project/tar.gz/develop");
+  });
+
+  it("should construct proper GitHub download URL", () => {
+    const url = getArchiveUrl({
+      branch: "feature/test",
+      owner: "my-org",
+      provider: "github",
+      repo: "my-repo",
+    });
+
+    expect(url).toBe("https://codeload.github.com/my-org/my-repo/tar.gz/feature/test");
+  });
+
+  it("should handle special characters in branch names", () => {
+    const url = getArchiveUrl({
+      branch: "fix/issue-123",
+      owner: "owner",
+      provider: "github",
+      repo: "repo",
+    });
+
+    expect(url).toBe("https://codeload.github.com/owner/repo/tar.gz/fix/issue-123");
+  });
+});

--- a/src/pkg/push/config.spec.ts
+++ b/src/pkg/push/config.spec.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ZodError } from "zod";
+import { loadPushConfig, resolveConfigPath } from "./config.js";
+
+describe("Push Config - Integration Test", () => {
+  let testBaseDir: string;
+
+  beforeEach(async () => {
+    testBaseDir = await mkdtemp(join(tmpdir(), "baedal-config-test-"));
+    await mkdir(join(testBaseDir, ".baedal/push"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testBaseDir, { force: true, recursive: true });
+  });
+
+  describe("resolveConfigPath", () => {
+    it("should resolve config path correctly", () => {
+      const path = resolveConfigPath("my-sync", testBaseDir);
+      expect(path).toBe(join(testBaseDir, ".baedal/push/my-sync.yml"));
+    });
+
+    it("should use current directory when baseDir not provided", () => {
+      const path = resolveConfigPath("test-sync");
+      expect(path).toContain(".baedal/push/test-sync.yml");
+    });
+  });
+
+  describe("loadPushConfig", () => {
+    it("should load valid config file", async () => {
+      const configYaml = `
+token: "test-token"
+syncs:
+  - dest: /dest
+    repos:
+      - owner/repo1
+      - owner/repo2
+    source: ./src
+`;
+      await writeFile(join(testBaseDir, ".baedal/push/test-sync.yml"), configYaml);
+
+      const config = loadPushConfig("test-sync", testBaseDir);
+
+      expect(config.syncs).toHaveLength(1);
+      expect(config.syncs[0]?.repos).toHaveLength(2);
+      expect(config.token).toBe("test-token");
+    });
+
+    it("should load config with multiple syncs", async () => {
+      const configYaml = `
+token: "github-token"
+syncs:
+  - dest: /src
+    repos:
+      - org/repo1
+    source: ./src
+  - dest: /docs
+    repos:
+      - org/repo2
+      - org/repo3
+    source: ./docs
+`;
+      await writeFile(join(testBaseDir, ".baedal/push/multi.yml"), configYaml);
+
+      const config = loadPushConfig("multi", testBaseDir);
+
+      expect(config.syncs).toHaveLength(2);
+      expect(config.syncs[0]?.source).toBe("./src");
+      expect(config.syncs[1]?.repos).toHaveLength(2);
+    });
+
+    it("should throw error when config file does not exist", () => {
+      expect(() => loadPushConfig("nonexistent", testBaseDir)).toThrow(
+        "Configuration file not found"
+      );
+    });
+
+    it("should throw error for invalid YAML", async () => {
+      const invalidYaml = `
+token: test
+syncs:
+  - invalid structure
+`;
+      await writeFile(join(testBaseDir, ".baedal/push/invalid.yml"), invalidYaml);
+
+      expect(() => loadPushConfig("invalid", testBaseDir)).toThrow(ZodError);
+    });
+
+    it("should throw error when required fields are missing", async () => {
+      const incompleteYaml = `
+token: "test-token"
+`;
+      await writeFile(join(testBaseDir, ".baedal/push/incomplete.yml"), incompleteYaml);
+
+      expect(() => loadPushConfig("incomplete", testBaseDir)).toThrow(ZodError);
+    });
+  });
+});

--- a/src/pkg/push/files.spec.ts
+++ b/src/pkg/push/files.spec.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectFiles, getRelativePath, normalizePath } from "./files.js";
+
+describe("Push Files - Integration Test", () => {
+  const MAX_FILE_SIZE_MB = 11;
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "baedal-files-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { force: true, recursive: true });
+  });
+
+  describe("normalizePath", () => {
+    it("should normalize Windows path to Unix", () => {
+      expect(normalizePath("src\\components\\Button.tsx")).toBe("src/components/Button.tsx");
+    });
+
+    it("should remove leading ./", () => {
+      expect(normalizePath("./src/utils.ts")).toBe("src/utils.ts");
+    });
+
+    it("should handle already normalized paths", () => {
+      expect(normalizePath("src/index.ts")).toBe("src/index.ts");
+    });
+  });
+
+  describe("getRelativePath", () => {
+    it("should get relative path between directories", () => {
+      const result = getRelativePath("/project/src", "/project/src/components/Button.tsx");
+      expect(result).toBe("components/Button.tsx");
+    });
+  });
+
+  describe("collectFiles", () => {
+    it("should collect single file", async () => {
+      const testFile = join(testDir, "test.ts");
+      await writeFile(testFile, "export const test = 1;");
+
+      const files = await collectFiles("test.ts", testDir);
+
+      expect(files).toHaveLength(1);
+      expect(files[0]?.path).toBe("test.ts");
+      expect(files[0]?.content).toBe("export const test = 1;");
+      expect(files[0]?.size).toBeGreaterThan(0);
+    });
+
+    it("should collect all files from directory", async () => {
+      await mkdir(join(testDir, "src"), { recursive: true });
+      await writeFile(join(testDir, "src/index.ts"), "console.log('index')");
+      await writeFile(join(testDir, "src/utils.ts"), "export const util = 1");
+
+      const files = await collectFiles("src", testDir);
+
+      expect(files).toHaveLength(2);
+      expect(files.map((f) => f.path).sort()).toEqual(["src/index.ts", "src/utils.ts"]);
+    });
+
+    it("should collect files from nested directories", async () => {
+      await mkdir(join(testDir, "src/components"), { recursive: true });
+      await mkdir(join(testDir, "src/utils"), { recursive: true });
+      await writeFile(join(testDir, "src/components/Button.tsx"), "export const Button = 1");
+      await writeFile(join(testDir, "src/utils/helper.ts"), "export const help = 1");
+      await writeFile(join(testDir, "src/index.ts"), "export *");
+
+      const files = await collectFiles("src", testDir);
+
+      expect(files.length).toBe(3);
+      const paths = files.map((f) => f.path).sort();
+      expect(paths[0]).toBe("src/components/Button.tsx");
+      expect(paths[1]).toBe("src/index.ts");
+      expect(paths[2]).toBe("src/utils/helper.ts");
+    });
+
+    it("should handle hidden files", async () => {
+      await mkdir(join(testDir, "src"), { recursive: true });
+      await writeFile(join(testDir, "src/.gitignore"), "node_modules");
+      await writeFile(join(testDir, "src/index.ts"), "code");
+
+      const files = await collectFiles("src", testDir);
+
+      expect(files.some((f) => f.path === "src/.gitignore")).toBe(true);
+    });
+
+    it("should throw error for file exceeding max size", async () => {
+      const largeContent = "x".repeat(MAX_FILE_SIZE_MB * 1024 * 1024);
+      await writeFile(join(testDir, "large.ts"), largeContent);
+
+      await expect(collectFiles("large.ts", testDir)).rejects.toThrow("exceeds maximum");
+    });
+
+    it("should throw error when no files found in directory", async () => {
+      await mkdir(join(testDir, "empty"), { recursive: true });
+
+      await expect(collectFiles("empty", testDir)).rejects.toThrow("No files found");
+    });
+
+    it("should throw error for non-existent path", async () => {
+      await expect(collectFiles("nonexistent.ts", testDir)).rejects.toThrow();
+    });
+
+    it("should include file content and size", async () => {
+      const content = "export const value = 42;";
+      await writeFile(join(testDir, "code.ts"), content);
+
+      const files = await collectFiles("code.ts", testDir);
+
+      expect(files[0]?.content).toBe(content);
+      expect(files[0]?.size).toBe(Buffer.byteLength(content));
+    });
+  });
+});


### PR DESCRIPTION
Improved test coverage from 42.51% to 54.44% by adding 4 integration test files

Added tests:
- check-existing.spec.ts: verify file existence checking logic
- archive.spec.ts: verify GitHub tarball URL generation
- config.spec.ts: verify YAML config file loading and validation
- files.spec.ts: verify file collection and normalization

Jest configuration improvements:
- add diagnostic error ignore settings (ESM compatibility)
- change isolatedModules to false for type checking

justfile enhancement:
- enable passing arguments to test command (e.g., just test --coverage)

Integration test strategy:
- use real file system without mocks (/tmp directory)
- setup test environment in beforeEach, cleanup in afterEach
- avoid Jest ESM mocking issues with high reliability through actual behavior verification

Added 27 test cases total (173 → 200)

fix #75