### PR TITLE
refactor: standardize error handling in download and files modules

### DIFF
--- a/src/internal/utils/download.spec.ts
+++ b/src/internal/utils/download.spec.ts
@@ -1,0 +1,24 @@
+import { NetworkError } from "../errors/index.js";
+
+describe("download - Error Validation", () => {
+  it("should verify NetworkError is thrown with URL context", () => {
+    const url = "https://api.github.com/repos/owner/repo/tarball";
+    const error = new NetworkError("Response body is empty", undefined, url);
+
+    expect(error).toBeInstanceOf(NetworkError);
+    expect(error.message).toBe("Response body is empty");
+    expect(error.url).toBe(url);
+    expect(error.code).toBe("NETWORK_ERROR");
+  });
+
+  it("should verify NetworkError includes proper error structure", () => {
+    const error = new NetworkError(
+      "Failed to download from GitHub: Response body is empty",
+      undefined,
+      "https://api.github.com/test"
+    );
+
+    expect(error.url).toBeDefined();
+    expect(error.message).toContain("Response body is empty");
+  });
+});

--- a/src/internal/utils/download.ts
+++ b/src/internal/utils/download.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import ky from "ky";
 import { getArchiveUrl, getDefaultBranch } from "../../pkg/pull/archive.js";
+import { NetworkError } from "../errors/index.js";
 import type { Provider } from "../types/providers.js";
 
 export const downloadTarball = async (
@@ -30,7 +31,11 @@ export const downloadTarball = async (
   const response = await ky.get(url, { headers });
 
   if (!response.body) {
-    throw new Error(`Failed to download from GitHub: Response body is empty`);
+    throw new NetworkError(
+      "Failed to download from GitHub: Response body is empty",
+      undefined,
+      url
+    );
   }
 
   const stream = Readable.fromWeb(response.body);


### PR DESCRIPTION
- Replace generic Error with NetworkError in download.ts to include URL context
- Apply FileSystemError at 4 error points in files.ts (file size exceeded, empty directory, collection failure, invalid path)
- Migrate console.warn to logger.warn for logging consistency and testability
- Add error type validation tests to ensure BaseError hierarchy usage

fix #88