### PR TITLE
refactor: utilize Provider type and improve extensibility

### DIFF
--- a/src/internal/types/providers.ts
+++ b/src/internal/types/providers.ts
@@ -1,4 +1,3 @@
-// TODO: Multi-provider support planned for after MVP (GitLab, Bitbucket)
 export type Provider = "github";
 
 export const GITHUB_API_URL = "https://api.github.com";

--- a/src/pkg/pull/archive.spec.ts
+++ b/src/pkg/pull/archive.spec.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "../../internal/errors/validation.js";
 import { getArchiveUrl } from "./archive.js";
 
 describe("getArchiveUrl", () => {
@@ -43,5 +44,25 @@ describe("getArchiveUrl", () => {
     });
 
     expect(url).toBe("https://codeload.github.com/owner/repo/tar.gz/fix/issue-123");
+  });
+
+  it("should throw ValidationError for unsupported provider", () => {
+    expect(() => {
+      getArchiveUrl({
+        branch: "main",
+        owner: "octocat",
+        provider: "gitlab" as any,
+        repo: "hello-world",
+      });
+    }).toThrow(ValidationError);
+
+    expect(() => {
+      getArchiveUrl({
+        branch: "main",
+        owner: "octocat",
+        provider: "gitlab" as any,
+        repo: "hello-world",
+      });
+    }).toThrow("Unsupported provider: gitlab");
   });
 });

--- a/src/pkg/pull/archive.ts
+++ b/src/pkg/pull/archive.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "../../internal/errors/validation.js";
 import type { Provider } from "../../internal/types/providers.js";
 import { GITHUB_ARCHIVE_URL } from "../../internal/types/providers.js";
 import { getGitHubDefaultBranch } from "./github.js";
@@ -8,8 +9,12 @@ export const getDefaultBranch = async (
   provider: Provider,
   token?: string
 ): Promise<string> => {
-  void provider;
-  return getGitHubDefaultBranch(owner, repo, token);
+  switch (provider) {
+    case "github":
+      return getGitHubDefaultBranch(owner, repo, token);
+    default:
+      throw new ValidationError(`Unsupported provider: ${provider}`);
+  }
 };
 
 type GetArchiveUrlParams = {
@@ -27,10 +32,14 @@ export const getArchiveUrl = ({
   repo,
   subdir,
 }: GetArchiveUrlParams): string => {
-  void provider;
   void subdir;
 
-  return GITHUB_ARCHIVE_URL.replace(/{owner}/g, owner)
-    .replace(/{repo}/g, repo)
-    .replace(/{branch}/g, branch);
+  switch (provider) {
+    case "github":
+      return GITHUB_ARCHIVE_URL.replace(/{owner}/g, owner)
+        .replace(/{repo}/g, repo)
+        .replace(/{branch}/g, branch);
+    default:
+      throw new ValidationError(`Unsupported provider: ${provider}`);
+  }
 };


### PR DESCRIPTION
- Remove void provider from getDefaultBranch and getArchiveUrl functions
- Implement Provider-based switch logic to prepare for GitLab, Bitbucket support
- Add early validation with ValidationError for unsupported providers
- Remove TODO comment in providers.ts and add test cases

fix #90