### PR TITLE
refactor: apply barrel export pattern and clean up import paths

### DIFF
--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,4 +1,4 @@
-import { program } from "./cli.js";
+import { program } from "./cli";
 
 describe("CLI Command Structure", () => {
   describe("pull command", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,10 @@
 import { Command } from "commander";
-import { adaptCLIOptions } from "./cli/adapter.js";
-import type { PullCLIOptions } from "./cli/types.js";
-import { logger } from "./internal/utils/logger.js";
-import { baedal } from "./pkg/pull/index.js";
-import { executePush, initPushConfig, loadPushConfig, printInitSuccess } from "./pkg/push/index.js";
-import type { PushInitCLIOptions } from "./pkg/push/types.js";
+import { adaptCLIOptions } from "./cli/adapter";
+import type { PullCLIOptions } from "./cli/types";
+import { logger } from "./internal/utils";
+import { baedal } from "./pkg/pull";
+import { executePush, initPushConfig, loadPushConfig, printInitSuccess } from "./pkg/push";
+import type { PushInitCLIOptions } from "./pkg/push/types";
 
 const program = new Command();
 

--- a/src/cli/adapter.spec.ts
+++ b/src/cli/adapter.spec.ts
@@ -1,5 +1,5 @@
-import { adaptCLIOptions } from "./adapter.js";
-import type { PullCLIOptions } from "./types.js";
+import { adaptCLIOptions } from "./adapter";
+import type { PullCLIOptions } from "./types";
 
 describe("adaptCLIOptions", () => {
   const originalEnv = process.env;

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -1,6 +1,6 @@
-import { ValidationError } from "../internal/errors/index.js";
-import type { BaedalOptions, ConflictMode } from "../internal/types/index.js";
-import type { PullCLIOptions } from "./types.js";
+import { ValidationError } from "../internal/errors";
+import type { BaedalOptions, ConflictMode } from "../internal/types";
+import type { PullCLIOptions } from "./types";
 
 const validateConflictFlags = (options: PullCLIOptions): void => {
   const conflictFlags = [options.force, options.skipExisting, options.noClobber].filter(Boolean);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,2 @@
+export type { PullCLIOptions } from "./types";
+export { adaptCLIOptions } from "./adapter";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { baedal } from "./pkg/pull/index.js";
-export type { BaedalOptions, PullResult } from "./internal/types/index.js";
+export type { BaedalOptions, PullResult } from "./internal/types";
+export { baedal } from "./pkg/pull";

--- a/src/internal/errors/base.spec.ts
+++ b/src/internal/errors/base.spec.ts
@@ -1,4 +1,4 @@
-import { BaseError } from "./base.js";
+import { BaseError } from "./base";
 
 describe("BaseError", () => {
   it("should create an error with message and code", () => {

--- a/src/internal/errors/filesystem.spec.ts
+++ b/src/internal/errors/filesystem.spec.ts
@@ -1,5 +1,4 @@
-import { BaseError } from "./base.js";
-import { ExtractionError, FileSystemError } from "./filesystem.js";
+import { BaseError, ExtractionError, FileSystemError } from ".";
 
 describe("FileSystemError", () => {
   it("should create an error with message and path", () => {

--- a/src/internal/errors/filesystem.ts
+++ b/src/internal/errors/filesystem.ts
@@ -1,4 +1,4 @@
-import { BaseError } from "./base.js";
+import { BaseError } from "./base";
 
 export class FileSystemError extends BaseError {
   constructor(

--- a/src/internal/errors/index.ts
+++ b/src/internal/errors/index.ts
@@ -1,4 +1,4 @@
-export { BaseError } from "./base.js";
-export { ExtractionError, FileSystemError } from "./filesystem.js";
-export { GitHubAPIError, NetworkError } from "./network.js";
-export { ConfigError, ValidationError } from "./validation.js";
+export { BaseError } from "./base";
+export { ExtractionError, FileSystemError } from "./filesystem";
+export { GitHubAPIError, NetworkError } from "./network";
+export { ConfigError, ValidationError } from "./validation";

--- a/src/internal/errors/network.spec.ts
+++ b/src/internal/errors/network.spec.ts
@@ -1,5 +1,4 @@
-import { BaseError } from "./base.js";
-import { GitHubAPIError, NetworkError } from "./network.js";
+import { BaseError, GitHubAPIError, NetworkError } from ".";
 
 describe("NetworkError", () => {
   it("should create NetworkError with message only", () => {

--- a/src/internal/errors/network.ts
+++ b/src/internal/errors/network.ts
@@ -1,4 +1,4 @@
-import { BaseError } from "./base.js";
+import { BaseError } from "./base";
 
 export class NetworkError extends BaseError {
   constructor(

--- a/src/internal/errors/validation.spec.ts
+++ b/src/internal/errors/validation.spec.ts
@@ -1,5 +1,4 @@
-import { BaseError } from "./base.js";
-import { ConfigError, ValidationError } from "./validation.js";
+import { BaseError, ConfigError, ValidationError } from ".";
 
 describe("ValidationError", () => {
   it("should create ValidationError with message only", () => {

--- a/src/internal/errors/validation.ts
+++ b/src/internal/errors/validation.ts
@@ -1,4 +1,4 @@
-import { BaseError } from "./base.js";
+import { BaseError } from "./base";
 
 export class ValidationError extends BaseError {
   constructor(

--- a/src/internal/types/index.spec.ts
+++ b/src/internal/types/index.spec.ts
@@ -1,4 +1,4 @@
-import type { BaedalOptions, ConflictMode } from "./index.js";
+import type { BaedalOptions, ConflictMode } from "./index";
 
 describe("ConflictMode", () => {
   test("should accept force mode", () => {

--- a/src/internal/types/index.ts
+++ b/src/internal/types/index.ts
@@ -1,4 +1,7 @@
-import type { Provider } from "./providers.js";
+import type { Provider as ProviderType } from "./providers";
+
+export type { Provider } from "./providers";
+export { DEFAULT_BRANCH, GITHUB_API_URL, GITHUB_ARCHIVE_URL } from "./providers";
 
 export type PullResult = {
   files: string[];
@@ -7,7 +10,7 @@ export type PullResult = {
 
 export type RepoInfo = {
   owner: string;
-  provider: Provider;
+  provider: ProviderType;
   repo: string;
   subdir?: string;
 };

--- a/src/internal/utils/check-existing.spec.ts
+++ b/src/internal/utils/check-existing.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkExistingFiles } from "./check-existing.js";
+import { checkExistingFiles } from "./check-existing";
 
 describe("checkExistingFiles - Integration Test", () => {
   let testDir: string;

--- a/src/internal/utils/check-existing.ts
+++ b/src/internal/utils/check-existing.ts
@@ -1,6 +1,6 @@
 import { access, constants } from "node:fs/promises";
 import { join } from "node:path";
-import type { FileCheckResult } from "../types/index.js";
+import type { FileCheckResult } from "../types";
 
 export const checkExistingFiles = async (
   files: string[],

--- a/src/internal/utils/download.spec.ts
+++ b/src/internal/utils/download.spec.ts
@@ -1,4 +1,4 @@
-import { NetworkError } from "../errors/index.js";
+import { NetworkError } from "../errors";
 
 describe("download - Error Validation", () => {
   it("should verify NetworkError is thrown with URL context", () => {

--- a/src/internal/utils/download.ts
+++ b/src/internal/utils/download.ts
@@ -2,9 +2,9 @@ import { createWriteStream } from "node:fs";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import ky from "ky";
-import { getArchiveUrl, getDefaultBranch } from "../../pkg/pull/archive.js";
-import { NetworkError } from "../errors/index.js";
-import type { Provider } from "../types/providers.js";
+import { getArchiveUrl, getDefaultBranch } from "../../pkg/pull";
+import { NetworkError } from "../errors";
+import type { Provider } from "../types";
 
 export const downloadTarball = async (
   owner: string,

--- a/src/internal/utils/extract.spec.ts
+++ b/src/internal/utils/extract.spec.ts
@@ -3,13 +3,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import micromatch from "micromatch";
 import { create } from "tar";
-import { ExtractionError, FileSystemError } from "../errors/index.js";
-import {
-  extractDirectly,
-  extractTarball,
-  extractViaTemp,
-  getFileListFromTarball,
-} from "./extract.js";
+import { ExtractionError, FileSystemError } from "../errors";
+import { extractDirectly, extractTarball, extractViaTemp, getFileListFromTarball } from "./extract";
 
 /**
  * Integration test helper for creating real tarballs.

--- a/src/internal/utils/extract.ts
+++ b/src/internal/utils/extract.ts
@@ -4,8 +4,8 @@ import { basename } from "node:path";
 import { globby } from "globby";
 import micromatch from "micromatch";
 import { extract, list } from "tar";
-import { ExtractionError, FileSystemError } from "../errors/index.js";
-import { joinPathSafe, stripRootDirectory } from "./path-helpers.js";
+import { ExtractionError, FileSystemError } from "../errors";
+import { joinPathSafe, stripRootDirectory } from "./path-helpers";
 
 const getNormalizedTarPath = (
   entryPath: string,

--- a/src/internal/utils/github-client.spec.ts
+++ b/src/internal/utils/github-client.spec.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "@octokit/rest";
-import { createGitHubClient, getTokenFromEnv } from "./github-client.js";
+import { createGitHubClient, getTokenFromEnv } from "./github-client";
 
 describe("github-client", () => {
   const originalEnv = process.env;

--- a/src/internal/utils/index.ts
+++ b/src/internal/utils/index.ts
@@ -1,0 +1,8 @@
+export { checkExistingFiles } from "./check-existing";
+export { downloadTarball } from "./download";
+export { extractDirectly, extractTarball, extractViaTemp, getFileListFromTarball } from "./extract";
+export { createGitHubClient, getTokenFromEnv } from "./github-client";
+export { logger } from "./logger";
+export { parseSource } from "./parser";
+export { joinPathSafe, normalizeGitHubPath, stripRootDirectory } from "./path-helpers";
+export { confirmOverwrite } from "./prompt";

--- a/src/internal/utils/parser.spec.ts
+++ b/src/internal/utils/parser.spec.ts
@@ -1,4 +1,4 @@
-import { parseSource } from "./parser.js";
+import { parseSource } from "./parser";
 
 describe("parseSource", () => {
   describe("basic format (user/repo)", () => {

--- a/src/internal/utils/parser.ts
+++ b/src/internal/utils/parser.ts
@@ -1,4 +1,4 @@
-import type { RepoInfo } from "../types/index.js";
+import type { RepoInfo } from "../types";
 
 export const parseSource = async (source: string): Promise<RepoInfo> => {
   const provider = "github" as const;

--- a/src/internal/utils/path-helpers.spec.ts
+++ b/src/internal/utils/path-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { sep } from "node:path";
-import { joinPathSafe, normalizeGitHubPath, stripRootDirectory } from "./path-helpers.js";
+import { joinPathSafe, normalizeGitHubPath, stripRootDirectory } from "./path-helpers";
 
 describe("stripRootDirectory", () => {
   describe("basic functionality", () => {

--- a/src/pkg/pull/archive.spec.ts
+++ b/src/pkg/pull/archive.spec.ts
@@ -1,5 +1,5 @@
-import { ValidationError } from "../../internal/errors/validation.js";
-import { getArchiveUrl } from "./archive.js";
+import { ValidationError } from "../../internal/errors";
+import { getArchiveUrl } from "./archive";
 
 describe("getArchiveUrl", () => {
   it("should generate GitHub tarball URL", () => {

--- a/src/pkg/pull/archive.ts
+++ b/src/pkg/pull/archive.ts
@@ -1,7 +1,6 @@
-import { ValidationError } from "../../internal/errors/validation.js";
-import type { Provider } from "../../internal/types/providers.js";
-import { GITHUB_ARCHIVE_URL } from "../../internal/types/providers.js";
-import { getGitHubDefaultBranch } from "./github.js";
+import { ValidationError } from "../../internal/errors";
+import { GITHUB_ARCHIVE_URL, type Provider } from "../../internal/types";
+import { getGitHubDefaultBranch } from "./github";
 
 export const getDefaultBranch = async (
   owner: string,

--- a/src/pkg/pull/github.ts
+++ b/src/pkg/pull/github.ts
@@ -1,5 +1,5 @@
 import ky from "ky";
-import { DEFAULT_BRANCH, GITHUB_API_URL } from "../../internal/types/providers.js";
+import { DEFAULT_BRANCH, GITHUB_API_URL } from "../../internal/types";
 
 export const getGitHubDefaultBranch = async (
   owner: string,

--- a/src/pkg/pull/index.spec.ts
+++ b/src/pkg/pull/index.spec.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { create } from "tar";
-import { FileSystemError, ValidationError } from "../../internal/errors/index.js";
+import { FileSystemError, ValidationError } from "../../internal/errors";
 
 /**
  * Integration test for pull functionality with focus on decomposed functions.

--- a/src/pkg/pull/index.ts
+++ b/src/pkg/pull/index.ts
@@ -1,14 +1,20 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { FileSystemError, ValidationError } from "../../internal/errors/index.js";
-import type { BaedalOptions, PullResult } from "../../internal/types/index.js";
-import { checkExistingFiles } from "../../internal/utils/check-existing.js";
-import { downloadTarball } from "../../internal/utils/download.js";
-import { extractTarball, getFileListFromTarball } from "../../internal/utils/extract.js";
-import { logger } from "../../internal/utils/logger.js";
-import { parseSource } from "../../internal/utils/parser.js";
-import { confirmOverwrite } from "../../internal/utils/prompt.js";
+import { FileSystemError, ValidationError } from "../../internal/errors";
+import type { BaedalOptions, PullResult } from "../../internal/types";
+import {
+  checkExistingFiles,
+  confirmOverwrite,
+  downloadTarball,
+  extractTarball,
+  getFileListFromTarball,
+  logger,
+  parseSource,
+} from "../../internal/utils";
+
+export { getArchiveUrl, getDefaultBranch } from "./archive";
+export { getGitHubDefaultBranch } from "./github";
 
 const DEFAULT_CONFLICT_MODE = "interactive";
 

--- a/src/pkg/push/config.spec.ts
+++ b/src/pkg/push/config.spec.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ZodError } from "zod";
-import { loadPushConfig, resolveConfigPath } from "./config.js";
+import { loadPushConfig, resolveConfigPath } from "./config";
 
 describe("Push Config - Integration Test", () => {
   let testBaseDir: string;

--- a/src/pkg/push/config.ts
+++ b/src/pkg/push/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import yaml from "js-yaml";
-import { PushConfigSchema, type PushConfig } from "./types.js";
+import { PushConfigSchema, type PushConfig } from ".";
 
 const CONFIG_DIR = ".baedal/push";
 

--- a/src/pkg/push/executor.spec.ts
+++ b/src/pkg/push/executor.spec.ts
@@ -1,11 +1,11 @@
-import { ConfigError } from "../../internal/errors/index.js";
+import { ConfigError } from "../../internal/errors";
 import {
   categorizeResults,
   executePush,
   prepareRepositories,
   validatePushConfig,
-} from "./executor.js";
-import type { PushConfig, PushResult } from "./types.js";
+} from "./executor";
+import type { PushConfig, PushResult } from ".";
 
 describe("executePush", () => {
   describe("Error Handling", () => {

--- a/src/pkg/push/executor.ts
+++ b/src/pkg/push/executor.ts
@@ -1,9 +1,9 @@
 import { join, relative } from "node:path";
-import { ConfigError, ValidationError } from "../../internal/errors/index.js";
-import { logger } from "../../internal/utils/logger.js";
-import { collectFiles } from "./files.js";
-import { createGitHubClient } from "./github.js";
-import type { PushConfig, PushExecutionResult, PushResult } from "./types.js";
+import { ConfigError, ValidationError } from "../../internal/errors";
+import { logger } from "../../internal/utils";
+import { collectFiles } from "./files";
+import { createGitHubClient } from "./github";
+import type { PushConfig, PushExecutionResult, PushResult } from "./types";
 
 const BRANCH_PREFIX = "sync";
 const SUMMARY_SEPARATOR_LENGTH = 60;

--- a/src/pkg/push/files.spec.ts
+++ b/src/pkg/push/files.spec.ts
@@ -1,8 +1,8 @@
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { FileSystemError } from "../../internal/errors/index.js";
-import { collectFiles, getRelativePath, normalizePath } from "./files.js";
+import { FileSystemError } from "../../internal/errors";
+import { collectFiles, getRelativePath, normalizePath } from "./files";
 
 describe("Push Files - Integration Test", () => {
   const MAX_FILE_SIZE_MB = 11;

--- a/src/pkg/push/files.ts
+++ b/src/pkg/push/files.ts
@@ -1,9 +1,9 @@
 import { readFile, stat } from "node:fs/promises";
 import { join, normalize, relative } from "node:path";
 import { globby } from "globby";
-import { FileSystemError } from "../../internal/errors/index.js";
-import { logger } from "../../internal/utils/logger.js";
-import type { CollectedFile } from "./types.js";
+import { FileSystemError } from "../../internal/errors";
+import { logger } from "../../internal/utils";
+import type { CollectedFile } from "./types";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 

--- a/src/pkg/push/github.ts
+++ b/src/pkg/push/github.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from "@octokit/rest";
-import { createGitHubClient as createOctokitClient } from "../../internal/utils/github-client.js";
-import { GIT_FILE_MODES, type CollectedFile } from "./types.js";
+import { createGitHubClient as createOctokitClient } from "../../internal/utils";
+import { GIT_FILE_MODES, type CollectedFile } from "./types";
 
 const DEFAULT_BRANCH = "main";
 

--- a/src/pkg/push/index.ts
+++ b/src/pkg/push/index.ts
@@ -1,6 +1,7 @@
-export { loadPushConfig } from "./config.js";
-export { executePush } from "./executor.js";
-export { collectFiles } from "./files.js";
-export { createGitHubClient } from "./github.js";
-export { initPushConfig, printInitSuccess } from "./init.js";
-export type * from "./types.js";
+export { loadPushConfig } from "./config";
+export { executePush } from "./executor";
+export { collectFiles } from "./files";
+export { createGitHubClient } from "./github";
+export { initPushConfig, printInitSuccess } from "./init";
+export { PushConfigSchema } from "./types";
+export type * from "./types";

--- a/src/pkg/push/init.ts
+++ b/src/pkg/push/init.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { logger } from "../../internal/utils/logger.js";
-import { resolveConfigPath } from "./config.js";
+import { logger } from "../../internal/utils";
+import { resolveConfigPath } from "./config";
 
 const generateTemplate = (syncName: string): string => {
   return `# Baedal Push Configuration: ${syncName}


### PR DESCRIPTION
- Add barrel exports (index.ts) to src/cli/ and src/internal/utils/ directories
- Enhance existing barrel exports (errors, types, pull) with re-exports
- Remove all .js extensions from TypeScript files for cleaner code
- Unify import paths to directory-level (e.g., from "./logger.js" → from "./utils")

fix #100